### PR TITLE
Draft: add SPSR submit-now shared abundance terms

### DIFF
--- a/ontology/modules/03-assessment-benchmarks.ttl
+++ b/ontology/modules/03-assessment-benchmarks.ttl
@@ -1,4 +1,4 @@
-@prefix smn: <https://w3id.org/smn/> .
+﻿@prefix smn: <https://w3id.org/smn/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix iao: <http://purl.obolibrary.org/obo/IAO_> .
@@ -17,6 +17,22 @@ smn:ObservedRateOrAbundance a owl:Class ;
   iao:0000115 "A measurement datum representing an empirically observed rate, count, or abundance derived from monitoring or survey data."@en ;
   rdfs:subClassOf iao:0000109 ;
   rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:CatchAbundance a owl:Class ;
+  rdfs:label "Catch abundance"@en ;
+  iao:0000115 "A measurement datum recording the number of salmon represented in fishery catch for a defined fishery, place, time, or stock context."@en ;
+  rdfs:subClassOf smn:ObservedRateOrAbundance ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
+  iao:0000119 "Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html."@en ;
+  dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> .
+
+smn:RecruitAbundance a owl:Class ;
+  rdfs:label "Recruit abundance"@en ;
+  iao:0000115 "A measurement datum recording the number of recruits added to a salmon stock, population, or indicator return series for a defined brood-year or assessment accounting context."@en ;
+  rdfs:subClassOf smn:ObservedRateOrAbundance ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
+  iao:0000119 "Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html."@en ;
+  dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> .
 
 smn:TargetOrLimitRateOrAbundance a owl:Class ;
   rdfs:label "Target or limit rate or abundance"@en ;

--- a/salmon-domain-ontology.ttl
+++ b/salmon-domain-ontology.ttl
@@ -171,6 +171,22 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf ns1:IAO_0000109 .
 
+<https://w3id.org/smn/CatchAbundance> a owl:Class ;
+    rdfs:label "Catch abundance"@en ;
+    ns1:IAO_0000115 "A measurement datum recording the number of salmon represented in fishery catch for a defined fishery, place, time, or stock context."@en ;
+    ns1:IAO_0000119 "Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html."@en ;
+    dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    rdfs:subClassOf <https://w3id.org/smn/ObservedRateOrAbundance> .
+
+<https://w3id.org/smn/RecruitAbundance> a owl:Class ;
+    rdfs:label "Recruit abundance"@en ;
+    ns1:IAO_0000115 "A measurement datum recording the number of recruits added to a salmon stock, population, or indicator return series for a defined brood-year or assessment accounting context."@en ;
+    ns1:IAO_0000119 "Fisheries and Oceans Canada. Pacific Salmon - Glossary (Pacific Region). https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html."@en ;
+    dcterms:source <https://www.pac.dfo-mpo.gc.ca/fm-gp/salmon-saumon/gloss-eng.html> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    rdfs:subClassOf <https://w3id.org/smn/ObservedRateOrAbundance> .
+
 <https://w3id.org/smn/OceanPhase> a skos:Concept ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     skos:altLabel "Marine phase"@en ;
@@ -639,4 +655,3 @@ sosa:FeatureOfInterest sosa:hasSample sosa:Sample .
 <https://w3id.org/smn> a owl:Ontology ;
     rdfs:label "Salmon Domain Ontology (modular build)"@en ;
     rdfs:comment "Primary modular import graph for reusable salmon-domain concepts and cross-ontology alignments. Phase-1/2/3 scaffold and migration baseline."@en .
-


### PR DESCRIPTION
## Summary
This draft batches the SPSR submit-now shared abundance term proposals into the Salmon Domain Ontology.

## Included terms
- smn:CatchAbundance (#15)
- smn:RecruitAbundance (#16)

## Files updated
- ontology/modules/03-assessment-benchmarks.ttl
- salmon-domain-ontology.ttl

## Notes
- The source module and flat TTL were both updated for the requested shared term batch.
- Generated docs artifacts were not refreshed in this pass.