### PR TITLE
docs: seed the OKF knowledge bundle (alignment-pass step 0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# salmon-domain-ontology — agent guidance
+
+The shared Salmon Domain Ontology (`smn:`, `https://w3id.org/smn`). Deliverables
+are Turtle artifacts plus publication and migration docs — no app code.
+
+## Knowledge bundle (read first)
+
+`knowledge/` is this repo's Open Knowledge Format bundle: durable,
+source-backed knowledge for agents and maintainers — the verified import
+graph, where modelling practice diverges from `CONVENTIONS.md`, and the
+cross-vocabulary alignment state with gcdfo and the PSC CV. Start at
+`knowledge/index.md` before substantial ontology or conventions work, and
+**update the relevant card when work changes or invalidates a recorded
+fact** — cards cite the commit they were verified against. The bundle is
+git-tracked and must contain no absolute filesystem paths. Validate from the
+repo root, with a sibling `psc-data-systems` checkout:
+
+```sh
+uv run --project ../psc-data-systems psc-okf check knowledge --tier capture
+```
+
+## Coordination
+
+Sequencing for cross-vocabulary work lives in the **metasalmon hub**
+(`metasalmon/knowledge/roadmap.md`, stream S9); the execplan is
+`metasalmon/knowledge/plans/2026-08-12-ontology-alignment-pass.md`. Do not
+maintain a competing roadmap here.
+
+## Before changing docs / ontology / builds
+
+- `knowledge/index.md` — verified repo knowledge (OKF bundle)
+- `README.md` — repo overview and build/release commands
+- `CONVENTIONS.md` — modeling and mapping-strength rules (canonical)
+- `ontology/modules/README.md` — module/build wiring
+- `docs/entrypoints.md` — what is actually used, and what to read before editing
+
+## Build / test
+
+```sh
+make verify-ontology-parse   # all TTLs parse
+make test                    # fast validation bundle
+make ci                      # full local CI bundle
+```
+
+Caution (verified, see the builds card): `make verify-flat-ttl` — and thus
+`make test`/`make ci` — currently **rewrites generated modules 08/09 in the
+working tree**; run on a clean tree. The root `salmon-domain-ontology.ttl` is
+generated; the hand-authored source is `ontology/salmon-domain-ontology.ttl`.

--- a/docs/entrypoints.md
+++ b/docs/entrypoints.md
@@ -74,6 +74,7 @@ Purpose: keep one short, reliable map of what starts the ontology builds, what i
 ## App Entry Points / Wiring
 
 - Main entry file(s):
+  - `knowledge/index.md` (OKF knowledge bundle: verified repo knowledge for agents/maintainers)
   - `ontology/salmon-domain-ontology.ttl`
   - `ontology/salmon-domain-ontology-research.ttl`
   - `ontology/salmon-domain-ontology-rda-case-study.ttl`
@@ -108,12 +109,14 @@ Purpose: keep one short, reliable map of what starts the ontology builds, what i
 
 - `https://w3id.org/smn` root, release, and canonical term-path routes are live via W3ID publication config; the term-dereferencing contract is mirrored under `docs/publishing/w3id-term-dereference-draft/`
 - Modeling rules and boundary decisions -> `CONVENTIONS.md` + `docs/migrations/phase2-boundary-rules.md`
+- Verified repo knowledge (import graph, conventions state, cross-vocabulary alignment) -> `knowledge/` OKF bundle; validate from `psc-data-systems` with `uv run psc-okf check <abs-path>/knowledge --tier capture`
 - Migration/cutover status and evidence -> `docs/migrations/README.md` + `docs/migrations/phase2-*.md` + `docs/migrations/evidence/`
 - Namespace/publication posture -> `docs/publishing/namespace-decision.md` + `docs/publishing/w3id-request-payload.md`
 
 ## What to read before editing
 
 - Changing ontology terms/modules/build imports:
+  - `knowledge/index.md` (verified findings that constrain conventions work)
   - `CONVENTIONS.md`
   - `ontology/modules/README.md`
   - `ontology/views/README.md` (if you are touching the optional metamodel view layer)

--- a/knowledge/bundle.psc.yaml
+++ b/knowledge/bundle.psc.yaml
@@ -1,0 +1,21 @@
+profile_version: '0.4'
+id: smn:bundle:ontology-knowledge
+title: Salmon Domain Ontology knowledge bundle
+default_domain: smn:domain:salmon-semantics
+contexts:
+  - smn:context:ontology-alignment-pass-2026
+source_registry: sources.psc.yaml
+review_registry: reviews.psc.yaml
+imports: []
+review_policy:
+  system_and_technical:
+    qualified_reviewers: []
+    minimum_outcome: qualified
+  data_domain:
+    qualified_reviewers: []
+    minimum_outcome: qualified
+publication:
+  classification: internal
+  audience:
+    - smn-maintainers
+  source_allowlist: []

--- a/knowledge/contexts/ontology-alignment-pass-2026.md
+++ b/knowledge/contexts/ontology-alignment-pass-2026.md
@@ -1,0 +1,15 @@
+---
+type: Context
+title: Ontology alignment pass 2026
+description: The cross-vocabulary conventions and alignment pass (smn, gcdfo, PSC CV) started 2026-08-12, tracked as roadmap stream S9 in the metasalmon repository.
+status: draft
+tags: [alignment, conventions]
+psc:
+  id: smn:context:ontology-alignment-pass-2026
+---
+
+Working context for this bundle's initial cards. The pass is sequenced in
+`metasalmon/knowledge/roadmap.md` (stream S9) with detail in
+`metasalmon/knowledge/plans/2026-08-12-ontology-alignment-pass.md`.
+Step 0 (recon: six survey agents + eight adversarially verified findings)
+completed 2026-08-12; the cards in `data/` carry its durable results.

--- a/knowledge/data/builds-and-import-graph.md
+++ b/knowledge/data/builds-and-import-graph.md
@@ -1,0 +1,65 @@
+---
+type: InformationObject
+title: Builds and import graph
+description: What each build variant buys, the exact import graph including its cycle and the views' relative imports, where generated output mixes with source, and the w3id dereference gaps.
+status: draft
+tags: [builds, imports, w3id, tooling]
+psc:
+  id: smn:data:builds-and-import-graph
+  contexts: [smn:context:ontology-alignment-pass-2026]
+---
+
+Verified 2026-08-12 against the working tree at commit `3995a17` (main).
+
+## The four build artifacts
+
+| Artifact | Nature | Imports |
+|---|---|---|
+| `ontology/salmon-domain-ontology.ttl` | hand-authored MAIN composition root (21 lines) | modules 01–07 + `alignment-main`, by **absolute w3id IRIs** |
+| `ontology/salmon-domain-ontology-research.ttl` | research root (9 lines) | `<https://w3id.org/smn>` + `alignment-research` |
+| `ontology/salmon-domain-ontology-rda-case-study.ttl` | case-study root (10 lines) | `<https://w3id.org/smn>` + generated bridge modules 08/09 |
+| `salmon-domain-ontology.ttl` (repo root) | **generated** import-stripped flattening of MAIN (`scripts/build_flat_smn_ttl.py`), drift-guarded by `make verify-flat-ttl` + CI | none |
+
+The root flat artifact shares a basename with the modular source — only a
+header comment distinguishes them, which invites wrong-file edits.
+
+## Import-graph facts that surprise people
+
+- **Cycle:** `<https://w3id.org/smn>` imports `alignment-main`
+  (`ontology/salmon-domain-ontology.ttl:21`) and `alignment-main.ttl:14`
+  imports `<https://w3id.org/smn>` back. Legal OWL, but the module cannot be
+  loaded standalone without pulling the whole ontology.
+- **Views are unreachable from every build**, the flat artifact, and both
+  sibling repos; `views/README.md` states this is deliberate. The composite
+  view `ontology/views/salmon-data-metamodel.ttl:7-14` is the **only** file
+  using relative (filename) `owl:imports` — resolvable solely from a local
+  checkout with siblings intact.
+- **No catalog file exists** (`catalog-v001.xml` or equivalent). The only
+  IRI→file resolution is `discover_local_ontology_index()` inside
+  `build_flat_smn_ttl.py`, keyed on *declared ontology IRIs* — so the views'
+  relative imports are invisible to it.
+
+## Generated vs hand-authored mixing
+
+- Bridge modules `08`/`09` under `ontology/modules/` are **generated**
+  (concatenated from `ontology/case-studies/` fragments) but sit beside
+  hand-authored modules; CI's drift gate (`make verify-generated-artifacts`,
+  Makefile:126) covers only `docs/` and the root flat TTL — a hand-edit to
+  08/09 passes CI and is silently clobbered by the next `make test`.
+- `make verify-flat-ttl` (and hence `make test` / `make ci`) **mutates the
+  working tree** (rewrites modules 08/09) — a verify target with write
+  side-effects (Makefile:102).
+- Every `REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit)`
+  block has **no generator**: `git log -S` shows they entered in authored
+  commit `2549f74` and no script writes or refreshes them.
+
+## w3id dereference gaps (live-checked 2026-08-12)
+
+- No rewrite rule matches `views/...` paths or the `smnv:` fragment
+  namespace — view IRIs 404 (`docs/publishing/w3id-htaccess.example:66-84`
+  mirrors the live rules).
+- Module IRIs dereference to **mutable** `raw.githubusercontent.com`
+  main-branch files, unlike the root/SemVer paths which hit the immutable
+  Pages release surface.
+- Profile **term** IRIs (e.g. `.../profile/hakai/...`) asserted in modules
+  08/09 have no dereference route either.

--- a/knowledge/data/cross-vocabulary-alignment-state.md
+++ b/knowledge/data/cross-vocabulary-alignment-state.md
@@ -1,0 +1,68 @@
+---
+type: InformationObject
+title: Cross-vocabulary alignment state
+description: The verified relationship between smn, gcdfo 0.0.8, and the PSC controlled vocabulary as of 2026-08-12 — the live pun, the minted term, the unbridged duplication, and why PSC maps to gcdfo but refuses smn.
+status: draft
+tags: [gcdfo, psc, sssom, alignment, methods]
+psc:
+  id: smn:data:cross-vocabulary-alignment-state
+  contexts: [smn:context:ontology-alignment-pass-2026]
+---
+
+Verified 2026-08-12: smn main `3995a17`, gcdfo main `c7a5425` (release
+0.0.8), psc-salmon-vocabularies branch `feature/fair-mapping-products-roadmap`
+(`8e50d81`).
+
+## The boundary is now structural, not prose
+
+`dfo-salmon.ttl:200` `owl:imports <https://w3id.org/smn>`; gcdfo subclasses
+smn upper classes 26 times and re-declares 39 `smn:` subjects as MIREOT-style
+mirrors (with `rdfs:isDefinedBy` pointed at smn per gcdfo's ownership rule).
+Any earlier claim that the smn/gcdfo boundary is "prose-only" is stale.
+
+## Defects in the merged closure
+
+- **Live pun:** `smn:EnumerationMethod` is `owl:Class ⊑ sosa:Procedure` in smn
+  (`modules/02:129`) and `skos:Concept` in gcdfo (`dfo-salmon.ttl:1024`).
+  Because gcdfo imports smn, every reasoner over the closure sees one IRI
+  typed both ways — which both repos' conventions forbid.
+- **Minted foreign term:** `smn:FisheriesReferencePointLower` is declared
+  only in `dfo-salmon.ttl` (~line 1920); smn never declares it.
+- **Unbridged duplication:** the 18-term age/year SKOS family exists twice —
+  smn module 07 carries migrated copies ("Migrated from GC DFO…") while gcdfo
+  retains the `gcdfo:` originals with **zero** `skos:exactMatch` bridges in
+  either direction.
+- **Zero-delta duplicates:** four gcdfo object properties
+  (`hasFeatureOfInterest`, `hasObservationResult`, `isSampleOfStratum`,
+  `usesObservationProcedure`) duplicate their smn twins' labels, definitions,
+  domains, and ranges verbatim, differing only by a `subPropertyOf` link.
+
+## Why PSC maps to gcdfo but refuses smn — the decisive field evidence
+
+The PSC CV is SKOS-only, CSV-authoritative, with mappings living exclusively
+in SSSOM TSVs gated by a review CSV and an allow-list of pinned sources.
+Released: **18 `skos:exactMatch` + 2 `closeMatch` to gcdfo** (pinned to gcdfo
+0.0.8, commit `c7a54251`) and 3 AGROVOC `closeMatch`. And
+`docs/sdo-alignment-gap.md` **explicitly refuses any psc→smn mapping set
+because smn's method anchor is an `owl:Class`, not a `skos:Concept`** — the
+"wrong-kind" objection. gcdfo's ADR-001 ("Methods as SKOS Concepts") is
+therefore winning in practice: the OWL-vs-SKOS methods decision is already
+determining which cross-vocabulary mappings exist.
+
+Consequences for the alignment pass (steps 2–4 of the execplan): migrating
+smn methods to SKOS (with thin `sosa:Procedure` instance typing) resolves the
+pun and dissolves PSC's objection in one move; the smn↔gcdfo boundary then
+gets one SSSOM set covering the ~55 term-name collisions and the age/year
+family.
+
+## PSC pipeline constraints to budget for
+
+- SHACL shapes are `sh:closed` — any SKOS enrichment (altLabels, in-graph
+  mappings, new statuses) is a build-breaking change requiring coordinated
+  shape + `build.py` + CSV edits.
+- `build.py:672` hard-codes SSSOM `mapping_date`; `build.py:18-30` hard-codes
+  scheme ids and the contiguous concept-id range.
+- PSC's promotion gate requires reuse by "two independently governed
+  organizations" — anchor via mappings, do not attempt term promotion.
+- gcdfo `docs/ADR.md` numbering disagrees with `docs/adr/` files (ADR-005/006
+  refer to different decisions in each place).

--- a/knowledge/data/owl-skos-conventions-state.md
+++ b/knowledge/data/owl-skos-conventions-state.md
@@ -1,0 +1,105 @@
+---
+type: InformationObject
+title: OWL/SKOS conventions — stated vs practiced
+description: Where the repository's modelling practice diverges from CONVENTIONS.md, with the eight adversarially verified metamodel findings (F1–F8) from the 2026-08-12 recon and the upstream-spec facts they rest on.
+status: draft
+tags: [owl, skos, conventions, metamodel, iadopt, sosa]
+psc:
+  id: smn:data:owl-skos-conventions-state
+  contexts: [smn:context:ontology-alignment-pass-2026]
+---
+
+Verified 2026-08-12 (main at `3995a17`). Fix plan: step 1 of
+`metasalmon/knowledge/plans/2026-08-12-ontology-alignment-pass.md`.
+
+## What holds
+
+- File-level OWL/SKOS separation is clean: modules 01–05 pure OWL (63
+  classes, 13 properties), module 07 pure SKOS (8 schemes, 36 concepts),
+  bridges 08/09 pure profile-namespace SKOS.
+- The dual-representation rule (`CONVENTIONS.md:72`) holds at the
+  explicit-typing level: **no IRI in `ontology/modules/` is declared both
+  `owl:Class` and `skos:Concept`** (scripted scan).
+- The §12 basis-vs-dimension split is honored (e.g. `smn:BroodYearBasis`
+  concept at `07:181` vs `smn:broodYear` datatype property at `02:303`), and
+  `ontology/examples/fraser-stock-recruit-year-age.ttl` follows it —
+  including using **native** `iadopt:hasProperty/hasObjectOfInterest/hasConstraint`.
+- Annotation completeness is bimodal by design history: modules 03/05/07
+  ~100% complete against §10; modules 01/02/04 carry exactly the 43 missing
+  definitions already tracked in `docs/annotation-gap-ledger.md`.
+
+## Verified divergences (adversarial verdicts, 2026-08-12)
+
+- **F1 (nuanced)** — the views assert OWL axioms on foreign subjects
+  (`iadopt:Variable rdfs:subClassOf iao:0000030, sosa:Property`
+  `views/salmon-data-metamodel-variable.ttl:14-15`; `sosa:Observation ⊑
+  prov:Activity` `event-observation:15`; three `sosa:* ⊑ prov:*` property
+  axioms `provenance:14-16`). Not an exposure incident (views unreachable —
+  see the builds card) but a policy gap: CONVENTIONS never says whether
+  foreign-subject Tier-1 axioms are permitted anywhere.
+- **F2 (confirmed)** — Tier-mixed pairs: `iadopt:Variable` gets Tier-1
+  `subClassOf` **and** Tier-3 `closeMatch` to `sosa:Property`
+  (`variable.ttl:14,69`); worse, the **default build** carries module 06's
+  `owl:equivalentClass sosa:Observation ≡ dwc:Occurrence` (`06:22`) alongside
+  alignment-main's `closeMatch` on the same pair (`alignment-main:81`).
+- **F3 (confirmed)** — `smnv:variableRepresentsProperty/…Entity/…UsesConstraint/…UsesStatisticalModifier`
+  duplicate I-ADOPT's native `iop:hasProperty/hasObjectOfInterest/hasConstraint/hasStatisticalModifier`
+  with no `subPropertyOf` bridges — while `smnv:constraintConstrains` *is*
+  bridged (`variable.ttl:65`) and the fraser example uses `iop:` directly.
+  Case-study walkthrough instance data is therefore invisible to
+  I-ADOPT-aware consumers.
+- **F4 (confirmed)** — relative `owl:imports` in the composite view; no
+  catalog; no w3id `views/` route (see the builds card).
+- **F5 (nuanced)** — `iadopt:Property ⊑ iao:0000030` is wrong by I-ADOPT's own
+  definition (Property = "a type of a characteristic", not a description) and
+  collides with module 06's `iadopt:Property owl:equivalentClass
+  sosa:Property`; ICE typing of `Variable`/`Constraint` is defensible by
+  I-ADOPT's wording.
+- **F6 (confirmed)** — `smn:EscapementMeasurement` (a **datum**,
+  ⊑ `iao:0000109`, `02:253`) is the lone `*Measurement` class that is not a
+  subclass of the **activity** `smn:Measurement` (`02:147`). The name
+  (inherited from gcdfo) is the defect; the view mappings are correct.
+- **F7 (nuanced)** — TDWG **redefined `dwc:Occurrence` on 2026-05-26** ("A
+  dwc:Event that establishes the state of a dwc:Organism…"), which makes
+  `sosa:Observation closeMatch dwc:Occurrence` defensible, but module 06's
+  `equivalentClass` versions (`06:22-23`) are indefensible under any DwC
+  vintage; `sosa:Sampling closeMatch dwc:Event` should weaken to
+  `broadMatch` (Event is strictly broader).
+- **F8 (nuanced)** — `smnv:variableUsesStatisticalModifier rdfs:range
+  owl:Thing` is an unnecessary placeholder: **I-ADOPT 1.1.0 has
+  `StatisticalModifier` + `iop:hasStatisticalModifier`**. No smn statistical
+  scheme exists among module 07's eight schemes.
+
+## Upstream facts these rest on (fetched 2026-08-12)
+
+- I-ADOPT current release **1.1.0** (2025-05-28): 9 classes (incl.
+  `StatisticalModifier`, `VariableSet`), 17 object properties;
+  ObjectOfInterest/ContextObject/Matrix are **roles, not classes**; no
+  unit/method component; **no published SOSA alignment**.
+- SOSA/SSN 2017 REC: all five published alignments (incl. PROV-O) are
+  **non-normative**; a 2023 Edition exists only as a First Public Working
+  Draft (2025-09-16) — do not pin conventions to it.
+- **Unresolved:** one verifier claimed the views' PROV axioms diverge from
+  W3C's `sosa-prov-mapping.ttl` (`hasFeatureOfInterest ⊑ prov:used`); the
+  upstream surveyor read that file and found they match. Read the mapping
+  file directly before writing any alignment-core module.
+- No authoritative DwC↔SOSA mapping exists anywhere; any assertion is a
+  local editorial commitment and belongs in a clearly-labeled alignment
+  module (SSN practice), never in a core module.
+
+## Module 02 latent modeling errors
+
+`02:213-214` applies object properties **between classes**
+(`sosa:FeatureOfInterest sosa:hasSample sosa:Sample`;
+`sosa:Sample sosa:isResultOf sosa:Sampling`). This is *legal* OWL 2 DL —
+using a class IRI in individual position is punning, and the two meanings are
+kept semantically separate — so a DL-profile gate will **not** flag it. That
+separation is exactly the problem: the triples relate the class-individuals
+and say **nothing about any instance**, while the author almost certainly
+intended instance-level semantics (e.g.
+`sosa:FeatureOfInterest ⊑ hasSample some sosa:Sample` restrictions) or a
+mere schema-level pointer (`rdfs:seeAlso`). Remedy (step 1): rewrite the
+axioms to say what is meant, and add a **targeted** CI report (a SPARQL query
+flagging object-property assertions whose subject or object is also an
+`owl:Class`) — the generic reasoner gate alone cannot catch this class of
+mistake.

--- a/knowledge/domains/salmon-semantics.md
+++ b/knowledge/domains/salmon-semantics.md
@@ -1,0 +1,16 @@
+---
+type: ScientificDataDomain
+title: Salmon semantics
+description: Shared cross-organization salmon-domain semantics — the smn ontology, its controlled vocabularies, and the conventions governing OWL vs SKOS modelling for salmon data interoperability.
+status: draft
+tags: [smn, ontology, semantics]
+psc:
+  id: smn:domain:salmon-semantics
+---
+
+The domain this bundle documents: the Salmon Domain Ontology (`smn:`,
+`https://w3id.org/smn/`) as the shared interoperability layer through which
+DFO (`gcdfo:`), PSC (PSC CV), and profile/project vocabularies exchange
+salmon-data semantics. The authoritative modelling rules are
+`CONVENTIONS.md` at the repository root; this bundle records verified
+knowledge *about* the repository that the conventions and README do not state.

--- a/knowledge/index.md
+++ b/knowledge/index.md
@@ -1,0 +1,30 @@
+---
+okf_version: "0.2"
+---
+
+# Salmon Domain Ontology — knowledge bundle
+
+Durable, source-backed knowledge about this repository for future agents and
+maintainers, in Open Knowledge Format (OKF) using the canonical PSC profile
+(v0.4) and its `psc-okf` validator from the canonical `psc-data-systems`
+repository (assumed checked out as a sibling of this repo).
+
+Seeded 2026-08-12 from the step-0 recon of the ontology conventions and
+alignment pass (execplan:
+`metasalmon/knowledge/plans/2026-08-12-ontology-alignment-pass.md`).
+
+## Cards
+
+- [Salmon semantics domain](domains/salmon-semantics.md)
+- [Ontology alignment pass 2026 (context)](contexts/ontology-alignment-pass-2026.md)
+- [Builds and import graph](data/builds-and-import-graph.md)
+- [OWL/SKOS conventions — stated vs practiced](data/owl-skos-conventions-state.md)
+- [Cross-vocabulary alignment state](data/cross-vocabulary-alignment-state.md)
+
+## Validation
+
+From this repo's root, with a sibling `psc-data-systems` checkout:
+
+```sh
+uv run --project ../psc-data-systems psc-okf check knowledge --tier capture
+```

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -1,0 +1,16 @@
+# Bundle log
+
+- 2026-08-12 — Bundle seeded from step-0 recon of the ontology alignment pass
+  (metasalmon roadmap S9). Five cards: domain, context, and three
+  InformationObject cards carrying the verified builds/imports facts, the
+  F1–F8 conventions findings, and the cross-vocabulary alignment state.
+  All cards `status: draft`; sources cited inline as file:line against the
+  commits named in each card. Validation: `psc-okf check --tier capture`.
+- 2026-08-13 — Codex review fixes: corrected the module-02 card (class-level
+  property assertions are legal OWL 2 DL punning, not OWL Full; remedy is a
+  targeted SPARQL report plus axiom rewrite, not the DL gate) and registered
+  the bundle in docs/entrypoints.md.
+- 2026-08-13 — Portability pass: removed all absolute filesystem paths (new
+  hub rule); validation command is now relative to a sibling psc-data-systems
+  checkout. Cross-repo references updated for metasalmon's notes/ -> knowledge/
+  migration.

--- a/knowledge/reviews.psc.yaml
+++ b/knowledge/reviews.psc.yaml
@@ -1,0 +1,2 @@
+profile_version: '0.4'
+reviews: []

--- a/knowledge/sources.psc.yaml
+++ b/knowledge/sources.psc.yaml
@@ -1,0 +1,2 @@
+profile_version: '0.4'
+sources: []


### PR DESCRIPTION
Seeds `knowledge/`, this repo's Open Knowledge Format bundle, from the 2026-08-12 ontology-alignment-pass recon, and points `AGENTS.md` at it.

Five cards, all `status: draft`, each citing the commit it was verified against:

- **Builds and import graph** — what each build variant buys; the root⇄alignment-main import cycle; the views' relative imports; the phantom "auto-generated" backfill blocks; verify targets that mutate source; the w3id dereference gaps.
- **OWL/SKOS conventions — stated vs practiced** — what holds (clean file-level split, dual-representation rule, §12 basis/dimension split) and the eight adversarially verified metamodel findings (F1–F8), with the upstream I-ADOPT 1.1.0 / SSN / TDWG facts they rest on.
- **Cross-vocabulary alignment state** — the live `smn:EnumerationMethod` pun with gcdfo 0.0.8, the minted `smn:FisheriesReferencePointLower`, the unbridged age/year duplication, and why PSC maps to gcdfo but refuses smn.

Uses the canonical PSC OKF profile v0.4; validated with
`uv run psc-okf check knowledge --tier capture` → `ok: true, 0 errors`.

The fix plan for the recorded findings is metasalmon roadmap stream S9
(`notes/exec-plans/2026-08-12-ontology-alignment-pass.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)