### PR TITLE
S9 step 1: import upstream alignments, demote unjustified equivalences, axiom-light views

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -16,7 +16,7 @@ Use for cross-agency concepts with stable semantics and reusable logical structu
 
 Examples:
 - biological entities (`Population`, `Deme`)
-- reusable monitoring/measurement semantics (`SurveyEvent`, `EscapementMeasurement`)
+- reusable monitoring/measurement semantics (`SurveyEvent`, `EscapementEstimate`)
 - reusable quantitative semantics (`ExploitationRate`)
 
 ### Layer B — Shared SKOS interoperability layer (`smn:`)
@@ -71,6 +71,16 @@ Use these to support ingestion, search, and migration without collapsing distinc
 
 A concept may exist as both OWL and SKOS **only with separate IRIs** and explicit mapping.
 
+### Instance-typing rule (2026-08-13)
+
+A SKOS concept MAY additionally be asserted an **instance** of a thin OWL
+class — for example a method concept typed `sosa:Procedure` so that
+`sosa:usedProcedure` remains type-correct. This is instance typing, not the
+class/concept punning the dual-representation rule forbids: the IRI is never
+both an `owl:Class` and a `skos:Concept`. This is the mechanism behind the
+methods-as-SKOS migration and the statistical-modifier scheme (concepts
+instance-typed `iadopt:StatisticalModifier`).
+
 ## 4) IRI strategy
 
 1. Shared terms use `smn:` IRIs.
@@ -107,6 +117,36 @@ Treat mapping predicates as different evidence strengths:
 
 Operational rule: Tier 3 links should not auto-canonicalize data into the production graph without review/promotion.
 
+## 5b) Mapping placement and coherence rules (2026-08-13)
+
+These close the policy gaps the alignment pass found (findings F1/F2/F5/F7).
+
+1. **One strongest mapping per pair.** A subject–object pair carries mapping
+   predicates from exactly one tier. The single documented exception is the
+   promotion-staging pattern: `alignment-main` may hold the Tier-3 form while
+   `alignment-research` holds the Tier-1 candidate for the same pair; nothing
+   else may duplicate a pair across tiers, and never within one module.
+2. **Foreign-subject axioms live only in alignment modules.** Logical axioms
+   (`rdfs:subClassOf`, `rdfs:subPropertyOf`, `owl:equivalent*`, instance-level
+   property assertions) whose **subject** is a term smn does not own are
+   permitted only in `alignment-upper`, `alignment-main`, and
+   `alignment-research`, each as a reviewed editorial commitment with a
+   rationale comment. Core modules (01–07) and views never state them.
+   Bare declaration stubs (`ex:Term a owl:Class .`) and documentation
+   annotations (`rdfs:comment`, `rdfs:seeAlso`) are allowed anywhere.
+3. **Import upstream alignments; do not restate them.** Where an upstream
+   body publishes the alignment (e.g. the W3C SOSA–PROV alignment),
+   `alignment-upper` imports it. Restating upstream axioms locally is how
+   mirrors drift.
+4. **Views are axiom-light.** The metamodel views are teaching surfaces:
+   smn-/smnv-owned subjects only, Tier-3 links at most, plus `subPropertyOf`
+   bridges from `smnv:` properties to their native upstream counterparts.
+5. **Reasoner-clean invariant.** The merged closure (smn + its imports +
+   gcdfo) must stay OWL-consistent with zero unsatisfiable classes, and no
+   IRI may be typed both `owl:Class` and `skos:Concept` anywhere in it.
+   A DL-profile gate does not catch class-as-individual modelling mistakes
+   (legal punning), so the CI check for those is a targeted SPARQL report.
+
 ## 6) Profile-to-domain bridge pattern
 
 When a profile concept corresponds to shared domain semantics:
@@ -118,7 +158,7 @@ When a profile concept corresponds to shared domain semantics:
 5. Attach provenance and reviewer metadata for each bridge.
 
 Example (conceptual):
-- `profile:SomeMethodConcept skos:closeMatch smn:EscapementMeasurement .`
+- `profile:SomeMethodConcept skos:closeMatch smn:EscapementEstimate .`
 - `profile:SomeMethodConcept prov:wasDerivedFrom <source-doc> .`
 
 ## 7) LLM-assisted integration policy

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -121,6 +121,11 @@ This ontology has the following classes and properties.</span>
       <a href="#/Deme" title="https://w3id.org/smn/Deme">Deme</a>
    </li>
    <li>
+      <a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity">
+         <span>Entity</span>
+      </a>
+   </li>
+   <li>
       <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a>
    </li>
    <li>
@@ -130,15 +135,10 @@ This ontology has the following classes and properties.</span>
       <a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a>
    </li>
    <li>
-      <a href="#/EscapementMeasurement" title="https://w3id.org/smn/EscapementMeasurement">Escapement measurement</a>
+      <a href="#/EscapementEstimate" title="https://w3id.org/smn/EscapementEstimate">Escapement estimate</a>
    </li>
    <li>
       <a href="#/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement survey event</a>
-   </li>
-   <li>
-      <a href="#http://rs.tdwg.org/dwc/terms/Event" title="http://rs.tdwg.org/dwc/terms/Event">
-         <span>Event</span>
-      </a>
    </li>
    <li>
       <a href="#/EventType" title="https://w3id.org/smn/EventType">Event type</a>
@@ -149,11 +149,6 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature">
          <span>Feature</span>
-      </a>
-   </li>
-   <li>
-      <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">
-         <span>Feature Of Interest</span>
       </a>
    </li>
    <li>
@@ -214,11 +209,6 @@ This ontology has the following classes and properties.</span>
       <a href="#/LimitReferencePoint" title="https://w3id.org/smn/LimitReferencePoint">Limit reference point</a>
    </li>
    <li>
-      <a href="#http://rs.tdwg.org/dwc/terms/MaterialSample" title="http://rs.tdwg.org/dwc/terms/MaterialSample">
-         <span>Material Sample</span>
-      </a>
-   </li>
-   <li>
       <a href="#/Measurement" title="https://w3id.org/smn/Measurement">Measurement</a>
    </li>
    <li>
@@ -251,11 +241,6 @@ This ontology has the following classes and properties.</span>
       <a href="#/ObservedRateOrAbundance" title="https://w3id.org/smn/ObservedRateOrAbundance">Observed rate or abundance</a>
    </li>
    <li>
-      <a href="#http://rs.tdwg.org/dwc/terms/Occurrence" title="http://rs.tdwg.org/dwc/terms/Occurrence">
-         <span>Occurrence</span>
-      </a>
-   </li>
-   <li>
       <a href="#/NCBITaxon_8018" title="https://w3id.org/smn/NCBITaxon_8018">Oncorhynchus keta proxy class</a>
    </li>
    <li>
@@ -267,11 +252,6 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">
          <span>Procedure</span>
-      </a>
-   </li>
-   <li>
-      <a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property">
-         <span>Property</span>
       </a>
    </li>
    <li>
@@ -345,6 +325,11 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#/TotalLengthMeasurement" title="https://w3id.org/smn/TotalLengthMeasurement">Total length measurement</a>
+   </li>
+   <li>
+      <a href="#https://w3id.org/iadopt/ont/Variable" title="https://w3id.org/iadopt/ont/Variable">
+         <span>Variable</span>
+      </a>
    </li>
 </ul><h4>Object Properties</h4><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -571,16 +556,15 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/Characteristic" title="https://w3id.org/smn/Characteristic">Characteristic</a></li>
   <li><a href="#/DataQualityAssessment" title="https://w3id.org/smn/DataQualityAssessment">Data quality assessment</a></li>
   <li><a href="#/Deme" title="https://w3id.org/smn/Deme">Deme</a></li>
+  <li><a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity"> <span>Entity</span> </a></li>
   <li><a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a></li>
   <li><a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a></li>
   <li><a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a></li>
-  <li><a href="#/EscapementMeasurement" title="https://w3id.org/smn/EscapementMeasurement">Escapement measurement</a></li>
+  <li><a href="#/EscapementEstimate" title="https://w3id.org/smn/EscapementEstimate">Escapement estimate</a></li>
   <li><a href="#/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement survey event</a></li>
-  <li><a href="#http://rs.tdwg.org/dwc/terms/Event" title="http://rs.tdwg.org/dwc/terms/Event"> <span>Event</span> </a></li>
   <li><a href="#/EventType" title="https://w3id.org/smn/EventType">Event type</a></li>
   <li><a href="#/ExploitationRate" title="https://w3id.org/smn/ExploitationRate">Exploitation rate</a></li>
   <li><a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature"> <span>Feature</span> </a></li>
-  <li><a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest"> <span>Feature Of Interest</span> </a></li>
   <li><a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a></li>
   <li><a href="#/FishLength" title="https://w3id.org/smn/FishLength">Fish length</a></li>
   <li><a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a></li>
@@ -599,7 +583,6 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/IndividualMeasurement" title="https://w3id.org/smn/IndividualMeasurement">Individual measurement</a></li>
   <li><a href="#/Life-HistoryCharacteristic" title="https://w3id.org/smn/Life-HistoryCharacteristic">Life-history characteristic</a></li>
   <li><a href="#/LimitReferencePoint" title="https://w3id.org/smn/LimitReferencePoint">Limit reference point</a></li>
-  <li><a href="#http://rs.tdwg.org/dwc/terms/MaterialSample" title="http://rs.tdwg.org/dwc/terms/MaterialSample"> <span>Material Sample</span> </a></li>
   <li><a href="#/Measurement" title="https://w3id.org/smn/Measurement">Measurement</a></li>
   <li><a href="#/MethodDocumentation" title="https://w3id.org/smn/MethodDocumentation">Method documentation</a></li>
   <li><a href="#/MetricBenchmark" title="https://w3id.org/smn/MetricBenchmark">Metric benchmark</a></li>
@@ -609,12 +592,10 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#http://www.w3.org/ns/sosa/Observation" title="http://www.w3.org/ns/sosa/Observation"> <span>Observation</span> </a></li>
   <li><a href="#/Observation" title="https://w3id.org/smn/Observation">Observation</a></li>
   <li><a href="#/ObservedRateOrAbundance" title="https://w3id.org/smn/ObservedRateOrAbundance">Observed rate or abundance</a></li>
-  <li><a href="#http://rs.tdwg.org/dwc/terms/Occurrence" title="http://rs.tdwg.org/dwc/terms/Occurrence"> <span>Occurrence</span> </a></li>
   <li><a href="#/NCBITaxon_8018" title="https://w3id.org/smn/NCBITaxon_8018">Oncorhynchus keta proxy class</a></li>
   <li><a href="#/orbitalLength" title="https://w3id.org/smn/orbitalLength">Orbital length</a></li>
   <li><a href="#/Population" title="https://w3id.org/smn/Population">Population</a></li>
   <li><a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure"> <span>Procedure</span> </a></li>
-  <li><a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property"> <span>Property</span> </a></li>
   <li><a href="#/RecruitAbundance" title="https://w3id.org/smn/RecruitAbundance">Recruit abundance</a></li>
   <li><a href="#/ReferencePoint" title="https://w3id.org/smn/ReferencePoint">Reference point</a></li>
   <li><a href="#/ReportingOrManagementStratum" title="https://w3id.org/smn/ReportingOrManagementStratum">Reporting or management stratum</a></li>
@@ -637,6 +618,7 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/TotalExploitationRate" title="https://w3id.org/smn/TotalExploitationRate">Total exploitation rate</a></li>
   <li><a href="#/totalLength" title="https://w3id.org/smn/totalLength">Total length</a></li>
   <li><a href="#/TotalLengthMeasurement" title="https://w3id.org/smn/TotalLengthMeasurement">Total length measurement</a></li>
+  <li><a href="#https://w3id.org/iadopt/ont/Variable" title="https://w3id.org/iadopt/ont/Variable"> <span>Variable</span> </a></li>
  </ul>
  <div class="entity" id="/Abundance">
   <h3>Abundance<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
@@ -794,7 +776,7 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
+    <a href="http://www.w3.org/ns/sosa/Property" target="_blank" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
@@ -873,6 +855,18 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="https://w3id.org/iadopt/ont/Entity">
+  <h3>Entity<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/iadopt/ont/Entity</p>
+  <dl class="description">
+   <dt>
+    has sub-classes
+   </dt>
+   <dd>
+    <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/Entity">
   <h3>Entity<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Entity</p>
@@ -889,7 +883,7 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="https://w3id.org/iadopt/ont/Entity" target="_blank" title="https://w3id.org/iadopt/ont/Entity">Entity</a> <sup class="type-c" title="class">c</sup>, <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+    <a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity">Entity</a> <sup class="type-c" title="class">c</sup>, <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
@@ -973,11 +967,14 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/EscapementMeasurement">
-  <h3>Escapement measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/EscapementMeasurement</p>
+ <div class="entity" id="/EscapementEstimate">
+  <h3>Escapement estimate<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/EscapementEstimate</p>
   <div class="comment">
    <span class="markdown">A measurement or estimate of escapement tied to a stock and a survey event.</span>
+  </div>
+  <div class="comment">
+   <span class="markdown">A datum (IAO measurement datum), not an activity: the corresponding survey activity is smn:EscapementSurveyEvent. Renamed from smn:EscapementMeasurement on 2026-08-13 (alignment pass, finding F6) because every other *Measurement class in this module is a subclass of the activity smn:Measurement, and this one is not — the name was the defect, inherited verbatim from gcdfo:EscapementMeasurement, whose hyponym family should be coordinated in the boundary pass.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -1035,24 +1032,6 @@ This section provides details for each class and property defined by Salmon Doma
   <dl class="description">
    <dt>
     has super-classes
-   </dt>
-   <dd>
-    <a href="#/SurveyEvent" title="https://w3id.org/smn/SurveyEvent">Survey event</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="http://rs.tdwg.org/dwc/terms/Event">
-  <h3>Event<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://rs.tdwg.org/dwc/terms/Event</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Sampling" title="http://www.w3.org/ns/sosa/Sampling">Sampling</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
    </dt>
    <dd>
     <a href="#/SurveyEvent" title="https://w3id.org/smn/SurveyEvent">Survey event</a> <sup class="type-c" title="class">c</sup>
@@ -1136,43 +1115,13 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+    <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
    </dt>
    <dd>
     <a href="#/GeographicFeature" title="https://w3id.org/smn/GeographicFeature">Geographic feature</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="http://www.w3.org/ns/sosa/FeatureOfInterest">
-  <h3>Feature Of Interest<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/FeatureOfInterest</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="https://w3id.org/iadopt/ont/Entity" target="_blank" title="https://w3id.org/iadopt/ont/Entity">Entity</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a> <sup class="type-c" title="class">c</sup>, <a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature">Feature</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    is in domain of
-   </dt>
-   <dd>
-    <a href="#/hasMeasurement" title="https://w3id.org/smn/hasMeasurement">has measurement</a> <sup class="type-op" title="object property">op</sup>
-   </dd>
-   <dt>
-    is in range of
-   </dt>
-   <dd>
-    <a href="#/characteristicFor" title="https://w3id.org/smn/characteristicFor">characteristic for</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -1609,18 +1558,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="http://rs.tdwg.org/dwc/terms/MaterialSample">
-  <h3>Material Sample<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://rs.tdwg.org/dwc/terms/MaterialSample</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Sample" title="http://www.w3.org/ns/sosa/Sample">Sample</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/Measurement">
   <h3>Measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Measurement</p>
@@ -1870,18 +1807,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="http://rs.tdwg.org/dwc/terms/Occurrence">
-  <h3>Occurrence<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://rs.tdwg.org/dwc/terms/Occurrence</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Observation" title="http://www.w3.org/ns/sosa/Observation">Observation</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/NCBITaxon_8018">
   <h3>Oncorhynchus keta proxy class<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/NCBITaxon_8018</p>
@@ -1977,30 +1902,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dt>
    <dd>
     <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>, <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="http://www.w3.org/ns/sosa/Property">
-  <h3>Property<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/Property</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="https://w3id.org/iadopt/ont/Property" target="_blank" title="https://w3id.org/iadopt/ont/Property">Property</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/Characteristic" title="https://w3id.org/smn/Characteristic">Characteristic</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    is in domain of
-   </dt>
-   <dd>
-    <a href="#/characteristicFor" title="https://w3id.org/smn/characteristicFor">characteristic for</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -2268,10 +2169,6 @@ This section provides details for each class and property defined by Salmon Doma
  <div class="entity" id="http://www.w3.org/ns/sosa/Sample">
   <h3>Sample<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/Sample</p>
-  <div class="comment">
-   <span class="markdown">Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows.</span>
-  </div>
-  <dl class="description"></dl>
  </div>
  <div class="entity" id="http://www.w3.org/ns/sosa/Sampling">
   <h3>Sampling<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
@@ -2475,7 +2372,7 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="#http://rs.tdwg.org/dwc/terms/Event" title="http://rs.tdwg.org/dwc/terms/Event">Event</a> <sup class="type-c" title="class">c</sup>
+    <a href="http://rs.tdwg.org/dwc/terms/Event" target="_blank" title="http://rs.tdwg.org/dwc/terms/Event">Event</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
@@ -2599,6 +2496,10 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="https://w3id.org/iadopt/ont/Variable">
+  <h3>Variable<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/iadopt/ont/Variable</p>
+ </div>
 </div><div xmlns:widoco="https://w3id.org/widoco/vocab#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="objectproperties">
  <h3 id="properties" class="list">Object Properties</h3>
  <ul class="hlist">
@@ -2658,13 +2559,13 @@ This section provides details for each class and property defined by Salmon Doma
      has domain
     </dt>
     <dd>
-     <a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
+     <a href="http://www.w3.org/ns/sosa/Property" target="_blank" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
     </dd>
     <dt>
      has range
     </dt>
     <dd>
-     <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+     <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
     </dd>
    </dl>
   </div>
@@ -2816,7 +2717,7 @@ This section provides details for each class and property defined by Salmon Doma
      has domain
     </dt>
     <dd>
-     <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+     <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
     </dd>
     <dt>
      has range
@@ -5663,7 +5564,60 @@ This section provides details for each class and property defined by Salmon Doma
 <h2 id="changes" class="list">Changes from last version</h2>
 <h3 id="changeClass" class="list">Classes</h3>
 <details><summary><u>Modified classes</u></summary>
-<ul><li><a href="#/CatchAbundance">https://w3id.org/smn/CatchAbundance</a>
+<ul><li><a href="#http://rs.tdwg.org/dwc/terms/Event">http://rs.tdwg.org/dwc/terms/Event</a>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Event&gt; &lt;http://www.w3.org/ns/sosa/Sampling&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/FeatureOfInterest">http://www.w3.org/ns/sosa/FeatureOfInterest</a>
+<ul>
+<li>Deleted: <http://www.w3.org/ns/sosa/hasSample> http://www.w3.org/ns/sosa/Sample</li>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://www.w3.org/ns/sosa/FeatureOfInterest&gt; &lt;https://w3id.org/iadopt/ont/Entity&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Observation">http://www.w3.org/ns/sosa/Observation</a>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Occurrence&gt; &lt;http://www.w3.org/ns/sosa/Observation&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Property">http://www.w3.org/ns/sosa/Property</a>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://www.w3.org/ns/sosa/Property&gt; &lt;https://w3id.org/iadopt/ont/Property&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Sample">http://www.w3.org/ns/sosa/Sample</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://rs.tdwg.org/dwc/terms/MaterialSample</li>
+</ul>
+<ul>
+<li>Deleted: <http://www.w3.org/ns/sosa/isResultOf> http://www.w3.org/ns/sosa/Sampling</li>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/MaterialSample&gt; &lt;http://www.w3.org/ns/sosa/Sample&gt;)</li>
+<li>Deleted: rdfs:comment "Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows."@en</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Sampling">http://www.w3.org/ns/sosa/Sampling</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#broadMatch> http://rs.tdwg.org/dwc/terms/Event</li>
+</ul>
+<ul>
+<li>Deleted: <http://www.w3.org/2004/02/skos/core#closeMatch> http://rs.tdwg.org/dwc/terms/Event</li>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Event&gt; &lt;http://www.w3.org/ns/sosa/Sampling&gt;)</li>
+</ul>
+</li>
+<li><a href="#https://w3id.org/iadopt/ont/Entity">https://w3id.org/iadopt/ont/Entity</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://www.w3.org/ns/sosa/FeatureOfInterest</li>
+</ul>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://www.w3.org/ns/sosa/FeatureOfInterest&gt; &lt;https://w3id.org/iadopt/ont/Entity&gt;)</li>
+</ul>
+</li>
+<li><a href="#https://w3id.org/iadopt/ont/Variable">https://w3id.org/iadopt/ont/Variable</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://www.w3.org/ns/sosa/ObservableProperty</li>
+</ul>
+</li>
+<li><a href="#/CatchAbundance">https://w3id.org/smn/CatchAbundance</a>
 <ul>
 <li>Added: rdfs:seeAlso https://w3id.org/smn/Abundance</li>
 <li>Added: rdfs:seeAlso https://w3id.org/smn/CatchYearBasis</li>
@@ -5683,12 +5637,6 @@ This section provides details for each class and property defined by Salmon Doma
 <li><a href="#/EnumerationMethod">https://w3id.org/smn/EnumerationMethod</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en</li>
-<li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
-</ul>
-</li>
-<li><a href="#/EscapementMeasurement">https://w3id.org/smn/EscapementMeasurement</a>
-<ul>
-<li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementMeasurement."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
 </ul>
 </li>
@@ -5765,6 +5713,20 @@ This section provides details for each class and property defined by Salmon Doma
 <ul>
 <li>Added: SubClass of https://w3id.org/smn/Characteristic</li>
 </ul>
+</li>
+<li><a href="#/EscapementEstimate">https://w3id.org/smn/EscapementEstimate</a>
+<ul>
+<li>Added: SubClass of http://purl.obolibrary.org/obo/IAO_0000109</li>
+</ul>
+</li>
+</ul></details><details><summary><u>Deleted classes</u></summary>
+<ul><li><a href="#http://rs.tdwg.org/dwc/terms/MaterialSample">http://rs.tdwg.org/dwc/terms/MaterialSample</a>
+</li>
+<li><a href="#http://rs.tdwg.org/dwc/terms/Occurrence">http://rs.tdwg.org/dwc/terms/Occurrence</a>
+</li>
+<li><a href="#https://w3id.org/iadopt/ont/Property">https://w3id.org/iadopt/ont/Property</a>
+</li>
+<li><a href="#/EscapementMeasurement">https://w3id.org/smn/EscapementMeasurement</a>
 </li>
 </ul></details><h3 id="changeProp" class="list">Object Properties</h3>
 <details><summary><u>Modified object properties</u></summary>

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,6 +121,11 @@ This ontology has the following classes and properties.</span>
       <a href="#/Deme" title="https://w3id.org/smn/Deme">Deme</a>
    </li>
    <li>
+      <a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity">
+         <span>Entity</span>
+      </a>
+   </li>
+   <li>
       <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a>
    </li>
    <li>
@@ -130,15 +135,10 @@ This ontology has the following classes and properties.</span>
       <a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a>
    </li>
    <li>
-      <a href="#/EscapementMeasurement" title="https://w3id.org/smn/EscapementMeasurement">Escapement measurement</a>
+      <a href="#/EscapementEstimate" title="https://w3id.org/smn/EscapementEstimate">Escapement estimate</a>
    </li>
    <li>
       <a href="#/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement survey event</a>
-   </li>
-   <li>
-      <a href="#http://rs.tdwg.org/dwc/terms/Event" title="http://rs.tdwg.org/dwc/terms/Event">
-         <span>Event</span>
-      </a>
    </li>
    <li>
       <a href="#/EventType" title="https://w3id.org/smn/EventType">Event type</a>
@@ -149,11 +149,6 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature">
          <span>Feature</span>
-      </a>
-   </li>
-   <li>
-      <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">
-         <span>Feature Of Interest</span>
       </a>
    </li>
    <li>
@@ -214,11 +209,6 @@ This ontology has the following classes and properties.</span>
       <a href="#/LimitReferencePoint" title="https://w3id.org/smn/LimitReferencePoint">Limit reference point</a>
    </li>
    <li>
-      <a href="#http://rs.tdwg.org/dwc/terms/MaterialSample" title="http://rs.tdwg.org/dwc/terms/MaterialSample">
-         <span>Material Sample</span>
-      </a>
-   </li>
-   <li>
       <a href="#/Measurement" title="https://w3id.org/smn/Measurement">Measurement</a>
    </li>
    <li>
@@ -251,11 +241,6 @@ This ontology has the following classes and properties.</span>
       <a href="#/ObservedRateOrAbundance" title="https://w3id.org/smn/ObservedRateOrAbundance">Observed rate or abundance</a>
    </li>
    <li>
-      <a href="#http://rs.tdwg.org/dwc/terms/Occurrence" title="http://rs.tdwg.org/dwc/terms/Occurrence">
-         <span>Occurrence</span>
-      </a>
-   </li>
-   <li>
       <a href="#/NCBITaxon_8018" title="https://w3id.org/smn/NCBITaxon_8018">Oncorhynchus keta proxy class</a>
    </li>
    <li>
@@ -267,11 +252,6 @@ This ontology has the following classes and properties.</span>
    <li>
       <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">
          <span>Procedure</span>
-      </a>
-   </li>
-   <li>
-      <a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property">
-         <span>Property</span>
       </a>
    </li>
    <li>
@@ -345,6 +325,11 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#/TotalLengthMeasurement" title="https://w3id.org/smn/TotalLengthMeasurement">Total length measurement</a>
+   </li>
+   <li>
+      <a href="#https://w3id.org/iadopt/ont/Variable" title="https://w3id.org/iadopt/ont/Variable">
+         <span>Variable</span>
+      </a>
    </li>
 </ul><h4>Object Properties</h4><ul xmlns:widoco="https://w3id.org/widoco/vocab#"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -571,16 +556,15 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/Characteristic" title="https://w3id.org/smn/Characteristic">Characteristic</a></li>
   <li><a href="#/DataQualityAssessment" title="https://w3id.org/smn/DataQualityAssessment">Data quality assessment</a></li>
   <li><a href="#/Deme" title="https://w3id.org/smn/Deme">Deme</a></li>
+  <li><a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity"> <span>Entity</span> </a></li>
   <li><a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a></li>
   <li><a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a></li>
   <li><a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a></li>
-  <li><a href="#/EscapementMeasurement" title="https://w3id.org/smn/EscapementMeasurement">Escapement measurement</a></li>
+  <li><a href="#/EscapementEstimate" title="https://w3id.org/smn/EscapementEstimate">Escapement estimate</a></li>
   <li><a href="#/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement survey event</a></li>
-  <li><a href="#http://rs.tdwg.org/dwc/terms/Event" title="http://rs.tdwg.org/dwc/terms/Event"> <span>Event</span> </a></li>
   <li><a href="#/EventType" title="https://w3id.org/smn/EventType">Event type</a></li>
   <li><a href="#/ExploitationRate" title="https://w3id.org/smn/ExploitationRate">Exploitation rate</a></li>
   <li><a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature"> <span>Feature</span> </a></li>
-  <li><a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest"> <span>Feature Of Interest</span> </a></li>
   <li><a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a></li>
   <li><a href="#/FishLength" title="https://w3id.org/smn/FishLength">Fish length</a></li>
   <li><a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a></li>
@@ -599,7 +583,6 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/IndividualMeasurement" title="https://w3id.org/smn/IndividualMeasurement">Individual measurement</a></li>
   <li><a href="#/Life-HistoryCharacteristic" title="https://w3id.org/smn/Life-HistoryCharacteristic">Life-history characteristic</a></li>
   <li><a href="#/LimitReferencePoint" title="https://w3id.org/smn/LimitReferencePoint">Limit reference point</a></li>
-  <li><a href="#http://rs.tdwg.org/dwc/terms/MaterialSample" title="http://rs.tdwg.org/dwc/terms/MaterialSample"> <span>Material Sample</span> </a></li>
   <li><a href="#/Measurement" title="https://w3id.org/smn/Measurement">Measurement</a></li>
   <li><a href="#/MethodDocumentation" title="https://w3id.org/smn/MethodDocumentation">Method documentation</a></li>
   <li><a href="#/MetricBenchmark" title="https://w3id.org/smn/MetricBenchmark">Metric benchmark</a></li>
@@ -609,12 +592,10 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#http://www.w3.org/ns/sosa/Observation" title="http://www.w3.org/ns/sosa/Observation"> <span>Observation</span> </a></li>
   <li><a href="#/Observation" title="https://w3id.org/smn/Observation">Observation</a></li>
   <li><a href="#/ObservedRateOrAbundance" title="https://w3id.org/smn/ObservedRateOrAbundance">Observed rate or abundance</a></li>
-  <li><a href="#http://rs.tdwg.org/dwc/terms/Occurrence" title="http://rs.tdwg.org/dwc/terms/Occurrence"> <span>Occurrence</span> </a></li>
   <li><a href="#/NCBITaxon_8018" title="https://w3id.org/smn/NCBITaxon_8018">Oncorhynchus keta proxy class</a></li>
   <li><a href="#/orbitalLength" title="https://w3id.org/smn/orbitalLength">Orbital length</a></li>
   <li><a href="#/Population" title="https://w3id.org/smn/Population">Population</a></li>
   <li><a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure"> <span>Procedure</span> </a></li>
-  <li><a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property"> <span>Property</span> </a></li>
   <li><a href="#/RecruitAbundance" title="https://w3id.org/smn/RecruitAbundance">Recruit abundance</a></li>
   <li><a href="#/ReferencePoint" title="https://w3id.org/smn/ReferencePoint">Reference point</a></li>
   <li><a href="#/ReportingOrManagementStratum" title="https://w3id.org/smn/ReportingOrManagementStratum">Reporting or management stratum</a></li>
@@ -637,6 +618,7 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/TotalExploitationRate" title="https://w3id.org/smn/TotalExploitationRate">Total exploitation rate</a></li>
   <li><a href="#/totalLength" title="https://w3id.org/smn/totalLength">Total length</a></li>
   <li><a href="#/TotalLengthMeasurement" title="https://w3id.org/smn/TotalLengthMeasurement">Total length measurement</a></li>
+  <li><a href="#https://w3id.org/iadopt/ont/Variable" title="https://w3id.org/iadopt/ont/Variable"> <span>Variable</span> </a></li>
  </ul>
  <div class="entity" id="/Abundance">
   <h3>Abundance<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
@@ -794,7 +776,7 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
+    <a href="http://www.w3.org/ns/sosa/Property" target="_blank" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
@@ -873,6 +855,18 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="https://w3id.org/iadopt/ont/Entity">
+  <h3>Entity<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/iadopt/ont/Entity</p>
+  <dl class="description">
+   <dt>
+    has sub-classes
+   </dt>
+   <dd>
+    <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/Entity">
   <h3>Entity<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Entity</p>
@@ -889,7 +883,7 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="https://w3id.org/iadopt/ont/Entity" target="_blank" title="https://w3id.org/iadopt/ont/Entity">Entity</a> <sup class="type-c" title="class">c</sup>, <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+    <a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity">Entity</a> <sup class="type-c" title="class">c</sup>, <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
@@ -973,11 +967,14 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/EscapementMeasurement">
-  <h3>Escapement measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/EscapementMeasurement</p>
+ <div class="entity" id="/EscapementEstimate">
+  <h3>Escapement estimate<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/EscapementEstimate</p>
   <div class="comment">
    <span class="markdown">A measurement or estimate of escapement tied to a stock and a survey event.</span>
+  </div>
+  <div class="comment">
+   <span class="markdown">A datum (IAO measurement datum), not an activity: the corresponding survey activity is smn:EscapementSurveyEvent. Renamed from smn:EscapementMeasurement on 2026-08-13 (alignment pass, finding F6) because every other *Measurement class in this module is a subclass of the activity smn:Measurement, and this one is not — the name was the defect, inherited verbatim from gcdfo:EscapementMeasurement, whose hyponym family should be coordinated in the boundary pass.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -1035,24 +1032,6 @@ This section provides details for each class and property defined by Salmon Doma
   <dl class="description">
    <dt>
     has super-classes
-   </dt>
-   <dd>
-    <a href="#/SurveyEvent" title="https://w3id.org/smn/SurveyEvent">Survey event</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="http://rs.tdwg.org/dwc/terms/Event">
-  <h3>Event<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://rs.tdwg.org/dwc/terms/Event</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Sampling" title="http://www.w3.org/ns/sosa/Sampling">Sampling</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
    </dt>
    <dd>
     <a href="#/SurveyEvent" title="https://w3id.org/smn/SurveyEvent">Survey event</a> <sup class="type-c" title="class">c</sup>
@@ -1136,43 +1115,13 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+    <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
    </dt>
    <dd>
     <a href="#/GeographicFeature" title="https://w3id.org/smn/GeographicFeature">Geographic feature</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="http://www.w3.org/ns/sosa/FeatureOfInterest">
-  <h3>Feature Of Interest<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/FeatureOfInterest</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="https://w3id.org/iadopt/ont/Entity" target="_blank" title="https://w3id.org/iadopt/ont/Entity">Entity</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a> <sup class="type-c" title="class">c</sup>, <a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature">Feature</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    is in domain of
-   </dt>
-   <dd>
-    <a href="#/hasMeasurement" title="https://w3id.org/smn/hasMeasurement">has measurement</a> <sup class="type-op" title="object property">op</sup>
-   </dd>
-   <dt>
-    is in range of
-   </dt>
-   <dd>
-    <a href="#/characteristicFor" title="https://w3id.org/smn/characteristicFor">characteristic for</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -1609,18 +1558,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="http://rs.tdwg.org/dwc/terms/MaterialSample">
-  <h3>Material Sample<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://rs.tdwg.org/dwc/terms/MaterialSample</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Sample" title="http://www.w3.org/ns/sosa/Sample">Sample</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/Measurement">
   <h3>Measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Measurement</p>
@@ -1870,18 +1807,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="http://rs.tdwg.org/dwc/terms/Occurrence">
-  <h3>Occurrence<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://rs.tdwg.org/dwc/terms/Occurrence</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Observation" title="http://www.w3.org/ns/sosa/Observation">Observation</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/NCBITaxon_8018">
   <h3>Oncorhynchus keta proxy class<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/NCBITaxon_8018</p>
@@ -1977,30 +1902,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dt>
    <dd>
     <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>, <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="http://www.w3.org/ns/sosa/Property">
-  <h3>Property<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/Property</p>
-  <dl class="description">
-   <dt>
-    is equivalent to
-   </dt>
-   <dd>
-    <a href="https://w3id.org/iadopt/ont/Property" target="_blank" title="https://w3id.org/iadopt/ont/Property">Property</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/Characteristic" title="https://w3id.org/smn/Characteristic">Characteristic</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    is in domain of
-   </dt>
-   <dd>
-    <a href="#/characteristicFor" title="https://w3id.org/smn/characteristicFor">characteristic for</a> <sup class="type-op" title="object property">op</sup>
    </dd>
   </dl>
  </div>
@@ -2268,10 +2169,6 @@ This section provides details for each class and property defined by Salmon Doma
  <div class="entity" id="http://www.w3.org/ns/sosa/Sample">
   <h3>Sample<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/Sample</p>
-  <div class="comment">
-   <span class="markdown">Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows.</span>
-  </div>
-  <dl class="description"></dl>
  </div>
  <div class="entity" id="http://www.w3.org/ns/sosa/Sampling">
   <h3>Sampling<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
@@ -2475,7 +2372,7 @@ This section provides details for each class and property defined by Salmon Doma
     has super-classes
    </dt>
    <dd>
-    <a href="#http://rs.tdwg.org/dwc/terms/Event" title="http://rs.tdwg.org/dwc/terms/Event">Event</a> <sup class="type-c" title="class">c</sup>
+    <a href="http://rs.tdwg.org/dwc/terms/Event" target="_blank" title="http://rs.tdwg.org/dwc/terms/Event">Event</a> <sup class="type-c" title="class">c</sup>
    </dd>
    <dt>
     has sub-classes
@@ -2599,6 +2496,10 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="https://w3id.org/iadopt/ont/Variable">
+  <h3>Variable<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/iadopt/ont/Variable</p>
+ </div>
 </div><div xmlns:widoco="https://w3id.org/widoco/vocab#" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="objectproperties">
  <h3 id="properties" class="list">Object Properties</h3>
  <ul class="hlist">
@@ -2658,13 +2559,13 @@ This section provides details for each class and property defined by Salmon Doma
      has domain
     </dt>
     <dd>
-     <a href="#http://www.w3.org/ns/sosa/Property" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
+     <a href="http://www.w3.org/ns/sosa/Property" target="_blank" title="http://www.w3.org/ns/sosa/Property">Property</a> <sup class="type-c" title="class">c</sup>
     </dd>
     <dt>
      has range
     </dt>
     <dd>
-     <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+     <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
     </dd>
    </dl>
   </div>
@@ -2816,7 +2717,7 @@ This section provides details for each class and property defined by Salmon Doma
      has domain
     </dt>
     <dd>
-     <a href="#http://www.w3.org/ns/sosa/FeatureOfInterest" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
+     <a href="http://www.w3.org/ns/sosa/FeatureOfInterest" target="_blank" title="http://www.w3.org/ns/sosa/FeatureOfInterest">Feature Of Interest</a> <sup class="type-c" title="class">c</sup>
     </dd>
     <dt>
      has range
@@ -5663,7 +5564,60 @@ This section provides details for each class and property defined by Salmon Doma
 <h2 id="changes" class="list">Changes from last version</h2>
 <h3 id="changeClass" class="list">Classes</h3>
 <details><summary><u>Modified classes</u></summary>
-<ul><li><a href="#/CatchAbundance">https://w3id.org/smn/CatchAbundance</a>
+<ul><li><a href="#http://rs.tdwg.org/dwc/terms/Event">http://rs.tdwg.org/dwc/terms/Event</a>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Event&gt; &lt;http://www.w3.org/ns/sosa/Sampling&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/FeatureOfInterest">http://www.w3.org/ns/sosa/FeatureOfInterest</a>
+<ul>
+<li>Deleted: <http://www.w3.org/ns/sosa/hasSample> http://www.w3.org/ns/sosa/Sample</li>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://www.w3.org/ns/sosa/FeatureOfInterest&gt; &lt;https://w3id.org/iadopt/ont/Entity&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Observation">http://www.w3.org/ns/sosa/Observation</a>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Occurrence&gt; &lt;http://www.w3.org/ns/sosa/Observation&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Property">http://www.w3.org/ns/sosa/Property</a>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://www.w3.org/ns/sosa/Property&gt; &lt;https://w3id.org/iadopt/ont/Property&gt;)</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Sample">http://www.w3.org/ns/sosa/Sample</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://rs.tdwg.org/dwc/terms/MaterialSample</li>
+</ul>
+<ul>
+<li>Deleted: <http://www.w3.org/ns/sosa/isResultOf> http://www.w3.org/ns/sosa/Sampling</li>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/MaterialSample&gt; &lt;http://www.w3.org/ns/sosa/Sample&gt;)</li>
+<li>Deleted: rdfs:comment "Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows."@en</li>
+</ul>
+</li>
+<li><a href="#http://www.w3.org/ns/sosa/Sampling">http://www.w3.org/ns/sosa/Sampling</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#broadMatch> http://rs.tdwg.org/dwc/terms/Event</li>
+</ul>
+<ul>
+<li>Deleted: <http://www.w3.org/2004/02/skos/core#closeMatch> http://rs.tdwg.org/dwc/terms/Event</li>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://rs.tdwg.org/dwc/terms/Event&gt; &lt;http://www.w3.org/ns/sosa/Sampling&gt;)</li>
+</ul>
+</li>
+<li><a href="#https://w3id.org/iadopt/ont/Entity">https://w3id.org/iadopt/ont/Entity</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://www.w3.org/ns/sosa/FeatureOfInterest</li>
+</ul>
+<ul>
+<li>Deleted: EquivalentClasses EquivalentClasses(&lt;http://www.w3.org/ns/sosa/FeatureOfInterest&gt; &lt;https://w3id.org/iadopt/ont/Entity&gt;)</li>
+</ul>
+</li>
+<li><a href="#https://w3id.org/iadopt/ont/Variable">https://w3id.org/iadopt/ont/Variable</a>
+<ul>
+<li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://www.w3.org/ns/sosa/ObservableProperty</li>
+</ul>
+</li>
+<li><a href="#/CatchAbundance">https://w3id.org/smn/CatchAbundance</a>
 <ul>
 <li>Added: rdfs:seeAlso https://w3id.org/smn/Abundance</li>
 <li>Added: rdfs:seeAlso https://w3id.org/smn/CatchYearBasis</li>
@@ -5683,12 +5637,6 @@ This section provides details for each class and property defined by Salmon Doma
 <li><a href="#/EnumerationMethod">https://w3id.org/smn/EnumerationMethod</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en</li>
-<li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
-</ul>
-</li>
-<li><a href="#/EscapementMeasurement">https://w3id.org/smn/EscapementMeasurement</a>
-<ul>
-<li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementMeasurement."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
 </ul>
 </li>
@@ -5765,6 +5713,20 @@ This section provides details for each class and property defined by Salmon Doma
 <ul>
 <li>Added: SubClass of https://w3id.org/smn/Characteristic</li>
 </ul>
+</li>
+<li><a href="#/EscapementEstimate">https://w3id.org/smn/EscapementEstimate</a>
+<ul>
+<li>Added: SubClass of http://purl.obolibrary.org/obo/IAO_0000109</li>
+</ul>
+</li>
+</ul></details><details><summary><u>Deleted classes</u></summary>
+<ul><li><a href="#http://rs.tdwg.org/dwc/terms/MaterialSample">http://rs.tdwg.org/dwc/terms/MaterialSample</a>
+</li>
+<li><a href="#http://rs.tdwg.org/dwc/terms/Occurrence">http://rs.tdwg.org/dwc/terms/Occurrence</a>
+</li>
+<li><a href="#https://w3id.org/iadopt/ont/Property">https://w3id.org/iadopt/ont/Property</a>
+</li>
+<li><a href="#/EscapementMeasurement">https://w3id.org/smn/EscapementMeasurement</a>
 </li>
 </ul></details><h3 id="changeProp" class="list">Object Properties</h3>
 <details><summary><u>Modified object properties</u></summary>

--- a/docs/migrations/gcdfo-to-salmon-wave1.csv
+++ b/docs/migrations/gcdfo-to-salmon-wave1.csv
@@ -10,7 +10,7 @@ https://w3id.org/gcdfo/salmon#hasPopulation,https://w3id.org/smn/hasPopulation,0
 https://w3id.org/gcdfo/salmon#populationOf,https://w3id.org/smn/populationOf,01-entity-systematics.ttl,migrated,re-scoped inverse
 https://w3id.org/gcdfo/salmon#SurveyEvent,https://w3id.org/smn/SurveyEvent,02-observation-measurement.ttl,migrated,shared monitoring event
 https://w3id.org/gcdfo/salmon#EscapementSurveyEvent,https://w3id.org/smn/EscapementSurveyEvent,02-observation-measurement.ttl,migrated,shared event
-https://w3id.org/gcdfo/salmon#EscapementMeasurement,https://w3id.org/smn/EscapementMeasurement,02-observation-measurement.ttl,migrated,shared measurement class
+https://w3id.org/gcdfo/salmon#EscapementMeasurement,https://w3id.org/smn/EscapementMeasurement,02-observation-measurement.ttl,migrated,"shared measurement class; smn side renamed to EscapementEstimate 2026-08-13 — see smn-internal-renames.csv"
 https://w3id.org/gcdfo/salmon#Escapement,https://w3id.org/smn/Escapement,02-observation-measurement.ttl,migrated,shared concept
 https://w3id.org/gcdfo/salmon#ObservedRateOrAbundance,https://w3id.org/smn/ObservedRateOrAbundance,03-assessment-benchmarks.ttl,migrated,shared base metric
 https://w3id.org/gcdfo/salmon#TargetOrLimitRateOrAbundance,https://w3id.org/smn/TargetOrLimitRateOrAbundance,03-assessment-benchmarks.ttl,migrated,shared base target/limit metric

--- a/docs/migrations/smn-internal-renames.csv
+++ b/docs/migrations/smn-internal-renames.csv
@@ -1,0 +1,2 @@
+old_iri,new_iri,module,status,notes
+https://w3id.org/smn/EscapementMeasurement,https://w3id.org/smn/EscapementEstimate,02-observation-measurement.ttl,renamed 2026-08-13,"F6: the class is an IAO measurement datum, and every other *Measurement class is an activity; direct replacement per CONVENTIONS section 9 alpha posture"

--- a/docs/smn.jsonld
+++ b/docs/smn.jsonld
@@ -160,20 +160,7 @@
     ]
   },
   {
-    "@id": "http://www.w3.org/ns/sosa/FeatureOfInterest",
-    "http://www.w3.org/ns/sosa/hasSample": [
-      {
-        "@id": "http://www.w3.org/ns/sosa/Sample"
-      }
-    ]
-  },
-  {
     "@id": "http://www.w3.org/ns/sosa/Observation",
-    "http://www.w3.org/2002/07/owl#equivalentClass": [
-      {
-        "@id": "http://rs.tdwg.org/dwc/terms/Occurrence"
-      }
-    ],
     "http://www.w3.org/2004/02/skos/core#closeMatch": [
       {
         "@id": "http://rs.tdwg.org/dwc/terms/Occurrence"
@@ -207,36 +194,18 @@
   },
   {
     "@id": "http://www.w3.org/ns/sosa/Sample",
-    "http://www.w3.org/2000/01/rdf-schema#comment": [
-      {
-        "@language": "en",
-        "@value": "Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows."
-      }
-    ],
-    "http://www.w3.org/2002/07/owl#equivalentClass": [
-      {
-        "@id": "http://rs.tdwg.org/dwc/terms/MaterialSample"
-      }
-    ],
     "http://www.w3.org/2004/02/skos/core#closeMatch": [
       {
         "@id": "http://rs.tdwg.org/dwc/terms/MaterialEntity"
-      }
-    ],
-    "http://www.w3.org/ns/sosa/isResultOf": [
+      },
       {
-        "@id": "http://www.w3.org/ns/sosa/Sampling"
+        "@id": "http://rs.tdwg.org/dwc/terms/MaterialSample"
       }
     ]
   },
   {
     "@id": "http://www.w3.org/ns/sosa/Sampling",
-    "http://www.w3.org/2002/07/owl#equivalentClass": [
-      {
-        "@id": "http://rs.tdwg.org/dwc/terms/Event"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+    "http://www.w3.org/2004/02/skos/core#broadMatch": [
       {
         "@id": "http://rs.tdwg.org/dwc/terms/Event"
       }
@@ -250,7 +219,7 @@
   },
   {
     "@id": "https://w3id.org/iadopt/ont/Entity",
-    "http://www.w3.org/2002/07/owl#equivalentClass": [
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
       {
         "@id": "http://www.w3.org/ns/sosa/FeatureOfInterest"
       }
@@ -258,7 +227,7 @@
   },
   {
     "@id": "https://w3id.org/iadopt/ont/Property",
-    "http://www.w3.org/2002/07/owl#equivalentClass": [
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
       {
         "@id": "http://www.w3.org/ns/sosa/Property"
       }
@@ -274,6 +243,11 @@
     "@id": "https://w3id.org/iadopt/ont/Variable",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "http://www.w3.org/ns/sosa/ObservableProperty"
+      }
     ]
   },
   {
@@ -1738,7 +1712,7 @@
     ]
   },
   {
-    "@id": "https://w3id.org/smn/EscapementMeasurement",
+    "@id": "https://w3id.org/smn/EscapementEstimate",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
@@ -1759,6 +1733,12 @@
         "@id": "https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl"
       }
     ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@language": "en",
+        "@value": "A datum (IAO measurement datum), not an activity: the corresponding survey activity is smn:EscapementSurveyEvent. Renamed from smn:EscapementMeasurement on 2026-08-13 (alignment pass, finding F6) because every other *Measurement class in this module is a subclass of the activity smn:Measurement, and this one is not — the name was the defect, inherited verbatim from gcdfo:EscapementMeasurement, whose hyponym family should be coordinated in the boundary pass."
+      }
+    ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
@@ -1767,7 +1747,7 @@
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
-        "@value": "Escapement measurement"
+        "@value": "Escapement estimate"
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
@@ -4770,13 +4750,41 @@
     "http://www.w3.org/2000/01/rdf-schema#comment": [
       {
         "@language": "en",
-        "@value": "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research)."
+        "@value": "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research). This is the only module in the default build permitted to carry mapping statements whose subjects are foreign-namespace terms (CONVENTIONS section 5b): each such statement is a reviewed editorial commitment, held at Tier 3 (advisory) unless an upstream body publishes the stronger form — in which case smn imports the upstream alignment (see alignment-upper) instead of restating it."
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#label": [
       {
         "@language": "en",
         "@value": "Salmon Domain Ontology Alignment Module (main-candidate)"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/smn/modules/alignment-upper",
+    "@type": [
+      "http://www.w3.org/2002/07/owl#Ontology"
+    ],
+    "http://purl.org/dc/terms/source": [
+      {
+        "@id": "http://www.w3.org/ns/sosa/prov"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@language": "en",
+        "@value": "Normative-core upper alignment. Imports the W3C-published SOSA-to-PROV-O alignment instead of re-asserting its axioms on foreign-namespace terms — the convention this module exists to enforce: smn never states axioms whose subjects it does not own outside a reviewed alignment module, and where an upstream body already publishes the alignment, smn imports it. The SOSA-PROV alignment is non-normative in the SSN Recommendation (2017, section 6.5); smn adopts it as the provenance backbone for the deterministic-reasoning consumption target. Offline and CI loading resolves the import to the vendored snapshot ontology/imports/sosa-prov.ttl via catalog-v001.xml; the snapshot is a byte copy of the W3C file and must not be hand-edited."
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#label": [
+      {
+        "@language": "en",
+        "@value": "Salmon Domain Ontology upper alignment (imported W3C alignments)"
+      }
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+      {
+        "@id": "https://www.w3.org/TR/vocab-ssn/#PROV"
       }
     ]
   },

--- a/docs/smn.owl
+++ b/docs/smn.owl
@@ -15,12 +15,14 @@
      xmlns:dcterms="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="https://w3id.org/smn/modules/01-entity-systematics">
         <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2026-08-04</dcterms:modified>
+        <dcterms:source rdf:resource="http://www.w3.org/ns/sosa/prov"/>
         <rdfs:comment xml:lang="en">Conservative shared event taxonomy. Policy/program-specific schemes remain in profile ontologies.</rdfs:comment>
         <rdfs:comment xml:lang="en">Conservative shared stock-assessment and benchmark semantics. Policy-program-specific reference classes remain profile-scoped.</rdfs:comment>
-        <rdfs:comment xml:lang="en">Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research).</rdfs:comment>
+        <rdfs:comment xml:lang="en">Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research). This is the only module in the default build permitted to carry mapping statements whose subjects are foreign-namespace terms (CONVENTIONS section 5b): each such statement is a reviewed editorial commitment, held at Tier 3 (advisory) unless an upstream body publishes the stronger form — in which case smn imports the upstream alignment (see alignment-upper) instead of restating it.</rdfs:comment>
         <rdfs:comment xml:lang="en">Core salmon entities, reporting strata, and composition relationships for cross-agency reuse. Includes migrated reusable structure terms from DFO Salmon Ontology (no removals from DFO source).</rdfs:comment>
         <rdfs:comment xml:lang="en">Cross-ontology bridge statements for SOSA, I-ADOPT, Darwin Core, RDF Data Cube, and OWL-Time interoperability.</rdfs:comment>
         <rdfs:comment xml:lang="en">Curated shared SKOS layer for reusable year basis, age, context, life-phase, and origin concepts. Policy/program-specific schemes remain profile-scoped by default.</rdfs:comment>
+        <rdfs:comment xml:lang="en">Normative-core upper alignment. Imports the W3C-published SOSA-to-PROV-O alignment instead of re-asserting its axioms on foreign-namespace terms — the convention this module exists to enforce: smn never states axioms whose subjects it does not own outside a reviewed alignment module, and where an upstream body already publishes the alignment, smn imports it. The SOSA-PROV alignment is non-normative in the SSN Recommendation (2017, section 6.5); smn adopts it as the provenance backbone for the deterministic-reasoning consumption target. Offline and CI loading resolves the import to the vendored snapshot ontology/imports/sosa-prov.ttl via catalog-v001.xml; the snapshot is a byte copy of the W3C file and must not be hand-edited.</rdfs:comment>
         <rdfs:comment xml:lang="en">Observation and measurement model (SOSA-aligned) with reusable abundance, typed year-coordinate properties, escapement, and survey terms.</rdfs:comment>
         <rdfs:comment xml:lang="en">Primary modular import graph for reusable salmon-domain concepts and cross-ontology alignments. Phase-1/2/3 scaffold and migration baseline.</rdfs:comment>
         <rdfs:comment xml:lang="en">Shared provenance and quality artifact classes. Program-specific confidence vocabularies remain profile-scoped.</rdfs:comment>
@@ -33,6 +35,8 @@
         <rdfs:label xml:lang="en">Salmon Domain Ontology Module 05: Provenance and quality</rdfs:label>
         <rdfs:label xml:lang="en">Salmon Domain Ontology Module 06: Data interoperability</rdfs:label>
         <rdfs:label xml:lang="en">Salmon Domain Ontology Module 07: Controlled vocabularies</rdfs:label>
+        <rdfs:label xml:lang="en">Salmon Domain Ontology upper alignment (imported W3C alignments)</rdfs:label>
+        <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/vocab-ssn/#PROV"/>
         <owl:priorVersion rdf:resource="https://w3id.org/smn/0.0.1"/>
         <owl:versionInfo>0.0.2</owl:versionInfo>
     </owl:Ontology>
@@ -137,18 +141,6 @@
     <!-- http://www.w3.org/2004/02/skos/core#scopeNote -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#scopeNote"/>
-
-
-
-    <!-- http://www.w3.org/ns/sosa/hasSample -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/sosa/hasSample"/>
-
-
-
-    <!-- http://www.w3.org/ns/sosa/isResultOf -->
-
-    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/sosa/isResultOf"/>
 
 
 
@@ -430,25 +422,7 @@
 
     <!-- http://rs.tdwg.org/dwc/terms/Event -->
 
-    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Event">
-        <owl:equivalentClass rdf:resource="http://www.w3.org/ns/sosa/Sampling"/>
-    </owl:Class>
-
-
-
-    <!-- http://rs.tdwg.org/dwc/terms/MaterialSample -->
-
-    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/MaterialSample">
-        <owl:equivalentClass rdf:resource="http://www.w3.org/ns/sosa/Sample"/>
-    </owl:Class>
-
-
-
-    <!-- http://rs.tdwg.org/dwc/terms/Occurrence -->
-
-    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Occurrence">
-        <owl:equivalentClass rdf:resource="http://www.w3.org/ns/sosa/Observation"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://rs.tdwg.org/dwc/terms/Event"/>
 
 
 
@@ -486,10 +460,7 @@
 
     <!-- http://www.w3.org/ns/sosa/FeatureOfInterest -->
 
-    <owl:Class rdf:about="http://www.w3.org/ns/sosa/FeatureOfInterest">
-        <owl:equivalentClass rdf:resource="https://w3id.org/iadopt/ont/Entity"/>
-        <sosa:hasSample rdf:resource="http://www.w3.org/ns/sosa/Sample"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://www.w3.org/ns/sosa/FeatureOfInterest"/>
 
 
 
@@ -511,18 +482,15 @@
 
     <!-- http://www.w3.org/ns/sosa/Property -->
 
-    <owl:Class rdf:about="http://www.w3.org/ns/sosa/Property">
-        <owl:equivalentClass rdf:resource="https://w3id.org/iadopt/ont/Property"/>
-    </owl:Class>
+    <owl:Class rdf:about="http://www.w3.org/ns/sosa/Property"/>
 
 
 
     <!-- http://www.w3.org/ns/sosa/Sample -->
 
     <owl:Class rdf:about="http://www.w3.org/ns/sosa/Sample">
-        <rdfs:comment xml:lang="en">Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows.</rdfs:comment>
         <skos:closeMatch rdf:resource="http://rs.tdwg.org/dwc/terms/MaterialEntity"/>
-        <sosa:isResultOf rdf:resource="http://www.w3.org/ns/sosa/Sampling"/>
+        <skos:closeMatch rdf:resource="http://rs.tdwg.org/dwc/terms/MaterialSample"/>
     </owl:Class>
 
 
@@ -530,7 +498,7 @@
     <!-- http://www.w3.org/ns/sosa/Sampling -->
 
     <owl:Class rdf:about="http://www.w3.org/ns/sosa/Sampling">
-        <skos:closeMatch rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
+        <skos:broadMatch rdf:resource="http://rs.tdwg.org/dwc/terms/Event"/>
     </owl:Class>
 
 
@@ -543,13 +511,9 @@
 
     <!-- https://w3id.org/iadopt/ont/Entity -->
 
-    <owl:Class rdf:about="https://w3id.org/iadopt/ont/Entity"/>
-
-
-
-    <!-- https://w3id.org/iadopt/ont/Property -->
-
-    <owl:Class rdf:about="https://w3id.org/iadopt/ont/Property"/>
+    <owl:Class rdf:about="https://w3id.org/iadopt/ont/Entity">
+        <skos:closeMatch rdf:resource="http://www.w3.org/ns/sosa/FeatureOfInterest"/>
+    </owl:Class>
 
 
 
@@ -561,7 +525,9 @@
 
     <!-- https://w3id.org/iadopt/ont/Variable -->
 
-    <owl:Class rdf:about="https://w3id.org/iadopt/ont/Variable"/>
+    <owl:Class rdf:about="https://w3id.org/iadopt/ont/Variable">
+        <skos:closeMatch rdf:resource="http://www.w3.org/ns/sosa/ObservableProperty"/>
+    </owl:Class>
 
 
 
@@ -694,15 +660,16 @@
 
 
 
-    <!-- https://w3id.org/smn/EscapementMeasurement -->
+    <!-- https://w3id.org/smn/EscapementEstimate -->
 
-    <owl:Class rdf:about="https://w3id.org/smn/EscapementMeasurement">
+    <owl:Class rdf:about="https://w3id.org/smn/EscapementEstimate">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000109"/>
         <ns1:IAO_0000115 xml:lang="en">A measurement or estimate of escapement tied to a stock and a survey event.</ns1:IAO_0000115>
         <ns1:IAO_0000119 xml:lang="en">GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementMeasurement.</ns1:IAO_0000119>
         <dcterms:source rdf:resource="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl"/>
+        <rdfs:comment xml:lang="en">A datum (IAO measurement datum), not an activity: the corresponding survey activity is smn:EscapementSurveyEvent. Renamed from smn:EscapementMeasurement on 2026-08-13 (alignment pass, finding F6) because every other *Measurement class in this module is a subclass of the activity smn:Measurement, and this one is not — the name was the defect, inherited verbatim from gcdfo:EscapementMeasurement, whose hyponym family should be coordinated in the boundary pass.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
-        <rdfs:label xml:lang="en">Escapement measurement</rdfs:label>
+        <rdfs:label xml:lang="en">Escapement estimate</rdfs:label>
         <skos:closeMatch rdf:resource="http://www.w3.org/ns/sosa/Result"/>
     </owl:Class>
 
@@ -2085,6 +2052,9 @@
         <rdfs:comment xml:lang="en">Documentation-level bridge only: in salmon data exchange this usually points to a Darwin Core protocol value or a DwC-DP Protocol record, not to an OWL-equivalent class.</rdfs:comment>
         <rdfs:seeAlso rdf:resource="http://rs.tdwg.org/dwc/terms/protocol"/>
         <rdfs:seeAlso rdf:resource="https://rs.tdwg.org/dwc/dp/terms/Protocol"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://w3id.org/iadopt/ont/Property">
+        <skos:closeMatch rdf:resource="http://www.w3.org/ns/sosa/Property"/>
     </rdf:Description>
     <rdf:Description rdf:about="https://w3id.org/smn/FisheriesReferencePointLower">
         <skos:closeMatch rdf:resource="https://w3id.org/iadopt/ont/Constraint"/>

--- a/docs/smn.ttl
+++ b/docs/smn.ttl
@@ -15,12 +15,14 @@
 
 <https://w3id.org/smn/modules/01-entity-systematics> rdf:type owl:Ontology ;
                                                       dcterms:modified "2026-08-04"^^xsd:date ;
+                                                      dcterms:source sosa:prov ;
                                                       rdfs:comment "Conservative shared event taxonomy. Policy/program-specific schemes remain in profile ontologies."@en ,
                                                                    "Conservative shared stock-assessment and benchmark semantics. Policy-program-specific reference classes remain profile-scoped."@en ,
-                                                                   "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research)."@en ,
+                                                                   "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research). This is the only module in the default build permitted to carry mapping statements whose subjects are foreign-namespace terms (CONVENTIONS section 5b): each such statement is a reviewed editorial commitment, held at Tier 3 (advisory) unless an upstream body publishes the stronger form — in which case smn imports the upstream alignment (see alignment-upper) instead of restating it."@en ,
                                                                    "Core salmon entities, reporting strata, and composition relationships for cross-agency reuse. Includes migrated reusable structure terms from DFO Salmon Ontology (no removals from DFO source)."@en ,
                                                                    "Cross-ontology bridge statements for SOSA, I-ADOPT, Darwin Core, RDF Data Cube, and OWL-Time interoperability."@en ,
                                                                    "Curated shared SKOS layer for reusable year basis, age, context, life-phase, and origin concepts. Policy/program-specific schemes remain profile-scoped by default."@en ,
+                                                                   "Normative-core upper alignment. Imports the W3C-published SOSA-to-PROV-O alignment instead of re-asserting its axioms on foreign-namespace terms — the convention this module exists to enforce: smn never states axioms whose subjects it does not own outside a reviewed alignment module, and where an upstream body already publishes the alignment, smn imports it. The SOSA-PROV alignment is non-normative in the SSN Recommendation (2017, section 6.5); smn adopts it as the provenance backbone for the deterministic-reasoning consumption target. Offline and CI loading resolves the import to the vendored snapshot ontology/imports/sosa-prov.ttl via catalog-v001.xml; the snapshot is a byte copy of the W3C file and must not be hand-edited."@en ,
                                                                    "Observation and measurement model (SOSA-aligned) with reusable abundance, typed year-coordinate properties, escapement, and survey terms."@en ,
                                                                    "Primary modular import graph for reusable salmon-domain concepts and cross-ontology alignments. Phase-1/2/3 scaffold and migration baseline."@en ,
                                                                    "Shared provenance and quality artifact classes. Program-specific confidence vocabularies remain profile-scoped."@en ;
@@ -32,7 +34,9 @@
                                                                  "Salmon Domain Ontology Module 04: Management and governance"@en ,
                                                                  "Salmon Domain Ontology Module 05: Provenance and quality"@en ,
                                                                  "Salmon Domain Ontology Module 06: Data interoperability"@en ,
-                                                                 "Salmon Domain Ontology Module 07: Controlled vocabularies"@en ;
+                                                                 "Salmon Domain Ontology Module 07: Controlled vocabularies"@en ,
+                                                                 "Salmon Domain Ontology upper alignment (imported W3C alignments)"@en ;
+                                                      rdfs:seeAlso <https://www.w3.org/TR/vocab-ssn/#PROV> ;
                                                       owl:priorVersion <https://w3id.org/smn/0.0.1> ;
                                                       owl:versionInfo "0.0.2" .
 
@@ -98,14 +102,6 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 
 ###  http://www.w3.org/2004/02/skos/core#scopeNote
 skos:scopeNote rdf:type owl:AnnotationProperty .
-
-
-###  http://www.w3.org/ns/sosa/hasSample
-sosa:hasSample rdf:type owl:AnnotationProperty .
-
-
-###  http://www.w3.org/ns/sosa/isResultOf
-sosa:isResultOf rdf:type owl:AnnotationProperty .
 
 
 #################################################################
@@ -289,18 +285,7 @@ qb:DimensionProperty rdf:type owl:Class .
 
 
 ###  http://rs.tdwg.org/dwc/terms/Event
-<http://rs.tdwg.org/dwc/terms/Event> rdf:type owl:Class ;
-                                     owl:equivalentClass sosa:Sampling .
-
-
-###  http://rs.tdwg.org/dwc/terms/MaterialSample
-<http://rs.tdwg.org/dwc/terms/MaterialSample> rdf:type owl:Class ;
-                                              owl:equivalentClass sosa:Sample .
-
-
-###  http://rs.tdwg.org/dwc/terms/Occurrence
-<http://rs.tdwg.org/dwc/terms/Occurrence> rdf:type owl:Class ;
-                                          owl:equivalentClass sosa:Observation .
+<http://rs.tdwg.org/dwc/terms/Event> rdf:type owl:Class .
 
 
 ###  http://rs.tdwg.org/dwc/terms/Organism
@@ -325,9 +310,7 @@ time:Instant rdf:type owl:Class .
 
 
 ###  http://www.w3.org/ns/sosa/FeatureOfInterest
-sosa:FeatureOfInterest rdf:type owl:Class ;
-                       owl:equivalentClass <https://w3id.org/iadopt/ont/Entity> ;
-                       sosa:hasSample sosa:Sample .
+sosa:FeatureOfInterest rdf:type owl:Class .
 
 
 ###  http://www.w3.org/ns/sosa/Observation
@@ -341,20 +324,18 @@ sosa:Procedure rdf:type owl:Class ;
 
 
 ###  http://www.w3.org/ns/sosa/Property
-sosa:Property rdf:type owl:Class ;
-              owl:equivalentClass <https://w3id.org/iadopt/ont/Property> .
+sosa:Property rdf:type owl:Class .
 
 
 ###  http://www.w3.org/ns/sosa/Sample
 sosa:Sample rdf:type owl:Class ;
-            rdfs:comment "Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows."@en ;
-            skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity> ;
-            sosa:isResultOf sosa:Sampling .
+            skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity> ,
+                            <http://rs.tdwg.org/dwc/terms/MaterialSample> .
 
 
 ###  http://www.w3.org/ns/sosa/Sampling
 sosa:Sampling rdf:type owl:Class ;
-              skos:closeMatch <http://rs.tdwg.org/dwc/terms/Event> .
+              skos:broadMatch <http://rs.tdwg.org/dwc/terms/Event> .
 
 
 ###  https://w3id.org/iadopt/ont/Constraint
@@ -362,11 +343,8 @@ sosa:Sampling rdf:type owl:Class ;
 
 
 ###  https://w3id.org/iadopt/ont/Entity
-<https://w3id.org/iadopt/ont/Entity> rdf:type owl:Class .
-
-
-###  https://w3id.org/iadopt/ont/Property
-<https://w3id.org/iadopt/ont/Property> rdf:type owl:Class .
+<https://w3id.org/iadopt/ont/Entity> rdf:type owl:Class ;
+                                     skos:closeMatch sosa:FeatureOfInterest .
 
 
 ###  https://w3id.org/iadopt/ont/StatisticalModifier
@@ -374,7 +352,8 @@ sosa:Sampling rdf:type owl:Class ;
 
 
 ###  https://w3id.org/iadopt/ont/Variable
-<https://w3id.org/iadopt/ont/Variable> rdf:type owl:Class .
+<https://w3id.org/iadopt/ont/Variable> rdf:type owl:Class ;
+                                       skos:closeMatch sosa:ObservableProperty .
 
 
 ###  https://w3id.org/smn/Abundance
@@ -474,15 +453,16 @@ sosa:Sampling rdf:type owl:Class ;
                                   rdfs:label "Escapement"@en .
 
 
-###  https://w3id.org/smn/EscapementMeasurement
-<https://w3id.org/smn/EscapementMeasurement> rdf:type owl:Class ;
-                                             rdfs:subClassOf ns1:IAO_0000109 ;
-                                             ns1:IAO_0000115 "A measurement or estimate of escapement tied to a stock and a survey event."@en ;
-                                             ns1:IAO_0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementMeasurement."@en ;
-                                             dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> ;
-                                             rdfs:isDefinedBy <https://w3id.org/smn> ;
-                                             rdfs:label "Escapement measurement"@en ;
-                                             skos:closeMatch sosa:Result .
+###  https://w3id.org/smn/EscapementEstimate
+<https://w3id.org/smn/EscapementEstimate> rdf:type owl:Class ;
+                                          rdfs:subClassOf ns1:IAO_0000109 ;
+                                          ns1:IAO_0000115 "A measurement or estimate of escapement tied to a stock and a survey event."@en ;
+                                          ns1:IAO_0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementMeasurement."@en ;
+                                          dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> ;
+                                          rdfs:comment "A datum (IAO measurement datum), not an activity: the corresponding survey activity is smn:EscapementSurveyEvent. Renamed from smn:EscapementMeasurement on 2026-08-13 (alignment pass, finding F6) because every other *Measurement class in this module is a subclass of the activity smn:Measurement, and this one is not — the name was the defect, inherited verbatim from gcdfo:EscapementMeasurement, whose hyponym family should be coordinated in the boundary pass."@en ;
+                                          rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                          rdfs:label "Escapement estimate"@en ;
+                                          skos:closeMatch sosa:Result .
 
 
 ###  https://w3id.org/smn/EscapementSurveyEvent
@@ -1537,6 +1517,9 @@ sosa:Sampling rdf:type owl:Class ;
 sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon data exchange this usually points to a Darwin Core protocol value or a DwC-DP Protocol record, not to an OWL-equivalent class."@en ;
                         rdfs:seeAlso <http://rs.tdwg.org/dwc/terms/protocol> ,
                                      <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
+
+
+<https://w3id.org/iadopt/ont/Property> skos:closeMatch sosa:Property .
 
 
 <https://w3id.org/smn/FisheriesReferencePointLower> skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .

--- a/knowledge/data/builds-and-import-graph.md
+++ b/knowledge/data/builds-and-import-graph.md
@@ -34,10 +34,13 @@ header comment distinguishes them, which invites wrong-file edits.
   view `ontology/views/salmon-data-metamodel.ttl:7-14` is the **only** file
   using relative (filename) `owl:imports` — resolvable solely from a local
   checkout with siblings intact.
-- **No catalog file exists** (`catalog-v001.xml` or equivalent). The only
-  IRI→file resolution is `discover_local_ontology_index()` inside
-  `build_flat_smn_ttl.py`, keyed on *declared ontology IRIs* — so the views'
-  relative imports are invisible to it.
+- ~~No catalog file exists~~ **Fixed 2026-08-13:** `ontology/catalog-v001.xml`
+  and `ontology/views/catalog-v001.xml` now map every module, view, and the
+  vendored W3C SOSA–PROV snapshot (`ontology/imports/sosa-prov.ttl`) to local
+  files; the composite view imports by ontology IRI. The main build now also
+  imports `modules/alignment-upper` (which imports the W3C alignment — the
+  first remote import in the graph; offline loading resolves it via the
+  catalog).
 
 ## Generated vs hand-authored mixing
 

--- a/knowledge/data/owl-skos-conventions-state.md
+++ b/knowledge/data/owl-skos-conventions-state.md
@@ -30,6 +30,18 @@ Verified 2026-08-12 (main at `3995a17`). Fix plan: step 1 of
 
 ## Verified divergences (adversarial verdicts, 2026-08-12)
 
+> **Status 2026-08-13 (S9 step 1, PR pending):** F1–F7 fixed and F8's
+> property-side fixed on branch `feat/s9-step1-alignment-semantics` — the
+> W3C SOSA–PROV alignment is now *imported* (new module `alignment-upper`,
+> vendored snapshot + `catalog-v001.xml`), module 06's equivalences are
+> demoted to reviewed Tier-3 bridges in `alignment-main`, the views are
+> axiom-light with `smnv:` properties bridged to native `iop:` properties,
+> `smn:EscapementMeasurement` is renamed `smn:EscapementEstimate`, module
+> 02's class-level property assertions are gone, and CONVENTIONS §5b now
+> states the one-strongest-mapping and foreign-subject rules (verified by
+> one-off rdflib checks: 0 violations; CI wiring is the follow-up PR).
+> F8's scheme (`smn:StatisticalModifierScheme`) is S9 step 5.
+
 - **F1 (nuanced)** — the views assert OWL axioms on foreign subjects
   (`iadopt:Variable rdfs:subClassOf iao:0000030, sosa:Property`
   `views/salmon-data-metamodel-variable.ttl:14-15`; `sosa:Observation ⊑

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -14,3 +14,5 @@
   hub rule); validation command is now relative to a sibling psc-data-systems
   checkout. Cross-repo references updated for metasalmon's notes/ -> knowledge/
   migration.
+- 2026-08-13 — S9 step 1 (alignment semantics): F1-F7 fixed, F8 property-side
+  fixed; conventions cards updated to reflect the landed state.

--- a/ontology/catalog-v001.xml
+++ b/ontology/catalog-v001.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <!-- Local IRI-to-file resolution for Protégé/ROBOT. Added 2026-08-13
+       (alignment pass F4): before this, only build_flat_smn_ttl.py could
+       resolve module IRIs offline. -->
+  <uri name="https://w3id.org/smn" uri="salmon-domain-ontology.ttl"/>
+  <uri name="https://w3id.org/smn/modules/01-entity-systematics" uri="modules/01-entity-systematics.ttl"/>
+  <uri name="https://w3id.org/smn/modules/02-observation-measurement" uri="modules/02-observation-measurement.ttl"/>
+  <uri name="https://w3id.org/smn/modules/03-assessment-benchmarks" uri="modules/03-assessment-benchmarks.ttl"/>
+  <uri name="https://w3id.org/smn/modules/04-management-governance" uri="modules/04-management-governance.ttl"/>
+  <uri name="https://w3id.org/smn/modules/05-provenance-quality" uri="modules/05-provenance-quality.ttl"/>
+  <uri name="https://w3id.org/smn/modules/06-data-interoperability" uri="modules/06-data-interoperability.ttl"/>
+  <uri name="https://w3id.org/smn/modules/07-controlled-vocabularies" uri="modules/07-controlled-vocabularies.ttl"/>
+  <uri name="https://w3id.org/smn/modules/alignment-main" uri="modules/alignment-main.ttl"/>
+  <uri name="https://w3id.org/smn/modules/alignment-upper" uri="modules/alignment-upper.ttl"/>
+  <uri name="https://w3id.org/smn/modules/alignment-research" uri="modules/alignment-research.ttl"/>
+  <uri name="https://w3id.org/smn/modules/08-rda-case-study-profile-bridges" uri="modules/08-rda-case-study-profile-bridges.ttl"/>
+  <uri name="https://w3id.org/smn/modules/09-rda-neville-decomposition-profile-bridges" uri="modules/09-rda-neville-decomposition-profile-bridges.ttl"/>
+  <uri name="http://www.w3.org/ns/sosa/prov" uri="imports/sosa-prov.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel" uri="views/salmon-data-metamodel.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/entity" uri="views/salmon-data-metamodel-entity.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/property" uri="views/salmon-data-metamodel-property.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/variable" uri="views/salmon-data-metamodel-variable.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/method-protocol" uri="views/salmon-data-metamodel-method-protocol.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/event-observation" uri="views/salmon-data-metamodel-event-observation.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/result-datum" uri="views/salmon-data-metamodel-result-datum.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/provenance" uri="views/salmon-data-metamodel-provenance.ttl"/>
+</catalog>

--- a/ontology/catalog-v001.xml
+++ b/ontology/catalog-v001.xml
@@ -17,6 +17,9 @@
   <uri name="https://w3id.org/smn/modules/08-rda-case-study-profile-bridges" uri="modules/08-rda-case-study-profile-bridges.ttl"/>
   <uri name="https://w3id.org/smn/modules/09-rda-neville-decomposition-profile-bridges" uri="modules/09-rda-neville-decomposition-profile-bridges.ttl"/>
   <uri name="http://www.w3.org/ns/sosa/prov" uri="imports/sosa-prov.ttl"/>
+  <uri name="http://www.w3.org/ns/prov-o#" uri="imports/prov-o.ttl"/>
+  <uri name="http://www.w3.org/ns/prov-o" uri="imports/prov-o.ttl"/>
+  <uri name="http://www.w3.org/ns/sosa/" uri="imports/sosa.ttl"/>
   <uri name="https://w3id.org/smn/views/salmon-data-metamodel" uri="views/salmon-data-metamodel.ttl"/>
   <uri name="https://w3id.org/smn/views/salmon-data-metamodel/entity" uri="views/salmon-data-metamodel-entity.ttl"/>
   <uri name="https://w3id.org/smn/views/salmon-data-metamodel/property" uri="views/salmon-data-metamodel-property.ttl"/>

--- a/ontology/imports/prov-o.ttl
+++ b/ontology/imports/prov-o.ttl
@@ -1,0 +1,1321 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+rdfs:comment
+    a owl:AnnotationProperty ;
+    rdfs:comment ""@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+rdfs:isDefinedBy
+    a owl:AnnotationProperty .
+
+rdfs:label
+    a owl:AnnotationProperty ;
+    rdfs:comment ""@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+rdfs:seeAlso
+    a owl:AnnotationProperty ;
+    rdfs:comment ""@en .
+
+owl:Thing
+    a owl:Class .
+
+owl:versionInfo
+    a owl:AnnotationProperty .
+
+<http://www.w3.org/ns/prov#>
+    a owl:Ontology .
+
+:Activity
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Activity" ;
+    owl:disjointWith :Entity ;
+    :category "starting-point" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities." ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Activity"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Activity"^^xsd:anyURI .
+
+:ActivityInfluence
+    a owl:Class ;
+    rdfs:comment "ActivityInfluence provides additional descriptions of an Activity's binary influence upon any other kind of resource. Instances of ActivityInfluence use the prov:activity property to cite the influencing Activity."@en, "It is not recommended that the type ActivityInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "ActivityInfluence" ;
+    rdfs:seeAlso :activity ;
+    rdfs:subClassOf :Influence, [
+        a owl:Restriction ;
+        owl:maxCardinality "0"^^xsd:nonNegativeInteger ;
+        owl:onProperty :hadActivity
+    ] ;
+    owl:disjointWith :EntityInfluence ;
+    :category "qualified" ;
+    :editorsDefinition "ActivitiyInfluence is the capacity of an activity to have an effect on the character, development, or behavior of another by means of generation, invalidation, communication, or other."@en .
+
+:Agent
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Agent" ;
+    owl:disjointWith :InstantaneousEvent ;
+    :category "starting-point" ;
+    :component "agents-responsibility" ;
+    :definition "An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity. "@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Agent"^^xsd:anyURI .
+
+:AgentInfluence
+    a owl:Class ;
+    rdfs:comment "AgentInfluence provides additional descriptions of an Agent's binary influence upon any other kind of resource. Instances of AgentInfluence use the prov:agent property to cite the influencing Agent."@en, "It is not recommended that the type AgentInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "AgentInfluence" ;
+    rdfs:seeAlso :agent ;
+    rdfs:subClassOf :Influence ;
+    :category "qualified" ;
+    :editorsDefinition "AgentInfluence is the capacity of an agent to have an effect on the character, development, or behavior of another by means of attribution, association, delegation, or other."@en .
+
+:Association
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Association provides additional descriptions about the binary prov:wasAssociatedWith relation from an prov:Activity to some prov:Agent that had some responsiblity for it. For example, :baking prov:wasAssociatedWith :baker; prov:qualifiedAssociation [ a prov:Association; prov:agent :baker; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Association" ;
+    rdfs:subClassOf :AgentInfluence ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :definition "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI ;
+    :unqualifiedForm :wasAssociatedWith .
+
+:Attribution
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Attribution provides additional descriptions about the binary prov:wasAttributedTo relation from an prov:Entity to some prov:Agent that had some responsible for it. For example, :cake prov:wasAttributedTo :baker; prov:qualifiedAttribution [ a prov:Attribution; prov:entity :baker; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Attribution" ;
+    rdfs:subClassOf :AgentInfluence ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition """Attribution is the ascribing of an entity to an agent.
+
+When an entity e is attributed to agent ag, entity e was generated by some unspecified activity that in turn was associated to agent ag. Thus, this relation is useful when the activity is not known, or irrelevant."""@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribution"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribution"^^xsd:anyURI ;
+    :unqualifiedForm :wasAttributedTo .
+
+:Bundle
+    a owl:Class ;
+    rdfs:comment "Note that there are kinds of bundles (e.g. handwritten letters, audio recordings, etc.) that are not expressed in PROV-O, but can be still be described by PROV-O."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Bundle" ;
+    rdfs:subClassOf :Entity ;
+    :category "expanded" ;
+    :definition "A bundle is a named set of provenance descriptions, and is itself an Entity, so allowing provenance of provenance to be expressed."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-bundle-entity"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-bundle-declaration"^^xsd:anyURI .
+
+:Collection
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Collection" ;
+    rdfs:subClassOf :Entity ;
+    :category "expanded" ;
+    :component "collections" ;
+    :definition "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection"^^xsd:anyURI .
+
+:Communication
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Communication provides additional descriptions about the binary prov:wasInformedBy relation from an informed prov:Activity to the prov:Activity that informed it. For example, :you_jumping_off_bridge prov:wasInformedBy :everyone_else_jumping_off_bridge; prov:qualifiedCommunication [ a prov:Communication; prov:activity :everyone_else_jumping_off_bridge; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Communication" ;
+    rdfs:subClassOf :ActivityInfluence ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Communication"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-wasInformedBy"^^xsd:anyURI ;
+    :unqualifiedForm :wasInformedBy .
+
+:Delegation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Delegation provides additional descriptions about the binary prov:actedOnBehalfOf relation from a performing prov:Agent to some prov:Agent for whom it was performed. For example, :mixing prov:wasAssociatedWith :toddler . :toddler prov:actedOnBehalfOf :mother; prov:qualifiedDelegation [ a prov:Delegation; prov:entity :mother; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Delegation" ;
+    rdfs:subClassOf :AgentInfluence ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :definition """Delegation is the assignment of authority and responsibility to an agent (by itself or by another agent) to carry out a specific activity as a delegate or representative, while the agent it acts on behalf of retains some responsibility for the outcome of the delegated work.
+
+For example, a student acted on behalf of his supervisor, who acted on behalf of the department chair, who acted on behalf of the university; all those agents are responsible in some way for the activity that took place but we do not say explicitly who bears responsibility and to what degree."""@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-delegation"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-delegation"^^xsd:anyURI ;
+    :unqualifiedForm :actedOnBehalfOf .
+
+:Derivation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Derivation provides additional descriptions about the binary prov:wasDerivedFrom relation from some derived prov:Entity to another prov:Entity from which it was derived. For example, :chewed_bubble_gum prov:wasDerivedFrom :unwrapped_bubble_gum; prov:qualifiedDerivation [ a prov:Derivation; prov:entity :unwrapped_bubble_gum; :foo :bar ]."@en, "The more specific forms of prov:Derivation (i.e., prov:Revision, prov:Quotation, prov:PrimarySource) should be asserted if they apply."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Derivation" ;
+    rdfs:subClassOf :EntityInfluence ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Derivation"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#Derivation-Relation"^^xsd:anyURI ;
+    :unqualifiedForm :wasDerivedFrom .
+
+:EmptyCollection
+    a owl:Class, owl:NamedIndividual ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "EmptyCollection"@en ;
+    rdfs:subClassOf :Collection ;
+    :category "expanded" ;
+    :component "collections" ;
+    :definition "An empty collection is a collection without members."@en .
+
+:End
+    a owl:Class ;
+    rdfs:comment "An instance of prov:End provides additional descriptions about the binary prov:wasEndedBy relation from some ended prov:Activity to an prov:Entity that ended it. For example, :ball_game prov:wasEndedBy :buzzer; prov:qualifiedEnd [ a prov:End; prov:entity :buzzer; :foo :bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "End" ;
+    rdfs:subClassOf :EntityInfluence, :InstantaneousEvent ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "End is when an activity is deemed to have been ended by an entity, known as trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end. An end may refer to a trigger entity that terminated the activity, or to an activity, known as ender that generated the trigger."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-End"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-End"^^xsd:anyURI ;
+    :unqualifiedForm :wasEndedBy .
+
+:Entity
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Entity" ;
+    owl:disjointWith :InstantaneousEvent ;
+    :category "starting-point" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "An entity is a physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary. "@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-entity"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Entity"^^xsd:anyURI .
+
+:EntityInfluence
+    a owl:Class ;
+    rdfs:comment "EntityInfluence provides additional descriptions of an Entity's binary influence upon any other kind of resource. Instances of EntityInfluence use the prov:entity property to cite the influencing Entity."@en, "It is not recommended that the type EntityInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "EntityInfluence" ;
+    rdfs:seeAlso :entity ;
+    rdfs:subClassOf :Influence ;
+    :category "qualified" ;
+    :editorsDefinition "EntityInfluence is the capacity of an entity to have an effect on the character, development, or behavior of another by means of usage, start, end, derivation, or other. "@en .
+
+:Generation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Generation provides additional descriptions about the binary prov:wasGeneratedBy relation from a generated prov:Entity to the prov:Activity that generated it. For example, :cake prov:wasGeneratedBy :baking; prov:qualifiedGeneration [ a prov:Generation; prov:activity :baking; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Generation" ;
+    rdfs:subClassOf :ActivityInfluence, :InstantaneousEvent ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Generation"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Generation"^^xsd:anyURI ;
+    :unqualifiedForm :wasGeneratedBy .
+
+:Influence
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Influence provides additional descriptions about the binary prov:wasInfluencedBy relation from some influenced Activity, Entity, or Agent to the influencing Activity, Entity, or Agent. For example, :stomach_ache prov:wasInfluencedBy :spoon; prov:qualifiedInfluence [ a prov:Influence; prov:entity :spoon; :foo :bar ] . Because prov:Influence is a broad relation, the more specific relations (Communication, Delegation, End, etc.) should be used when applicable."@en, "Because prov:Influence is a broad relation, its most specific subclasses (e.g. prov:Communication, prov:Delegation, prov:End, prov:Revision, etc.) should be used when applicable."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Influence" ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :definition "Influence is the capacity of an entity, activity, or agent to have an effect on the character, development, or behavior of another by means of usage, start, end, generation, invalidation, communication, derivation, attribution, association, or delegation."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-influence"^^xsd:anyURI ;
+    :unqualifiedForm :wasInfluencedBy .
+
+:InstantaneousEvent
+    a owl:Class ;
+    rdfs:comment "An instantaneous event, or event for short, happens in the world and marks a change in the world, in its activities and in its entities. The term 'event' is commonly used in process algebra with a similar meaning. Events represent communications or interactions; they are assumed to be atomic and instantaneous."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "InstantaneousEvent" ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#dfn-event"^^xsd:anyURI ;
+    :definition "The PROV data model is implicitly based on a notion of instantaneous events (or just events), that mark transitions in the world. Events include generation, usage, or invalidation of entities, as well as starting or ending of activities. This notion of event is not first-class in the data model, but it is useful for explaining its other concepts and its semantics."@en .
+
+:Invalidation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Invalidation provides additional descriptions about the binary prov:wasInvalidatedBy relation from an invalidated prov:Entity to the prov:Activity that invalidated it. For example, :uncracked_egg prov:wasInvalidatedBy :baking; prov:qualifiedInvalidation [ a prov:Invalidation; prov:activity :baking; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Invalidation" ;
+    rdfs:subClassOf :ActivityInfluence, :InstantaneousEvent ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "Invalidation is the start of the destruction, cessation, or expiry of an existing entity by an activity. The entity is no longer available for use (or further invalidation) after invalidation. Any generation or usage of an entity precedes its invalidation." ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Invalidation"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Invalidation"^^xsd:anyURI ;
+    :unqualifiedForm :wasInvalidatedBy .
+
+:Location
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Location" ;
+    rdfs:seeAlso :atLocation ;
+    :category "expanded" ;
+    :definition "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-location"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI .
+
+:Organization
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Organization" ;
+    rdfs:subClassOf :Agent ;
+    :category "expanded" ;
+    :component "agents-responsibility" ;
+    :definition "An organization is a social or legal institution such as a company, society, etc." ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+:Person
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Person" ;
+    rdfs:subClassOf :Agent ;
+    :category "expanded" ;
+    :component "agents-responsibility" ;
+    :definition "Person agents are people."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+:Plan
+    a owl:Class ;
+    rdfs:comment "There exist no prescriptive requirement on the nature of plans, their representation, the actions or steps they consist of, or their intended goals. Since plans may evolve over time, it may become necessary to track their provenance, so plans themselves are entities. Representing the plan explicitly in the provenance can be useful for various tasks: for example, to validate the execution as represented in the provenance record, to manage expectation failures, or to provide explanations."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Plan" ;
+    rdfs:subClassOf :Entity ;
+    :category "expanded", "qualified" ;
+    :component "agents-responsibility" ;
+    :definition "A plan is an entity that represents a set of actions or steps intended by one or more agents to achieve some goals." ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI .
+
+:PrimarySource
+    a owl:Class ;
+    rdfs:comment "An instance of prov:PrimarySource provides additional descriptions about the binary prov:hadPrimarySource relation from some secondary prov:Entity to an earlier, primary prov:Entity. For example, :blog prov:hadPrimarySource :newsArticle; prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :newsArticle; :foo :bar ] ."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "PrimarySource" ;
+    rdfs:subClassOf :Derivation ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :definition """A primary source for a topic refers to something produced by some agent with direct experience and knowledge about the topic, at the time of the topic's study, without benefit from hindsight.
+
+Because of the directness of primary sources, they 'speak for themselves' in ways that cannot be captured through the filter of secondary sources. As such, it is important for secondary sources to reference those primary sources from which they were derived, so that their reliability can be investigated.
+
+A primary source relation is a particular case of derivation of secondary materials from their primary sources. It is recognized that the determination of primary sources can be up to interpretation, and should be done according to conventions accepted within the application's domain."""@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-primary-source"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-original-source"^^xsd:anyURI ;
+    :unqualifiedForm :hadPrimarySource .
+
+:Quotation
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Quotation provides additional descriptions about the binary prov:wasQuotedFrom relation from some taken prov:Entity from an earlier, larger prov:Entity. For example, :here_is_looking_at_you_kid prov:wasQuotedFrom :casablanca_script; prov:qualifiedQuotation [ a prov:Quotation; prov:entity :casablanca_script; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Quotation" ;
+    rdfs:subClassOf :Derivation ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :definition "A quotation is the repeat of (some or all of) an entity, such as text or image, by someone who may or may not be its original author. Quotation is a particular case of derivation."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-quotation"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-quotation"^^xsd:anyURI ;
+    :unqualifiedForm :wasQuotedFrom .
+
+:Revision
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Revision provides additional descriptions about the binary prov:wasRevisionOf relation from some newer prov:Entity to an earlier prov:Entity. For example, :draft_2 prov:wasRevisionOf :draft_1; prov:qualifiedRevision [ a prov:Revision; prov:entity :draft_1; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Revision" ;
+    rdfs:subClassOf :Derivation ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :definition "A revision is a derivation for which the resulting entity is a revised version of some original. The implication here is that the resulting entity contains substantial content from the original. Revision is a particular case of derivation."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-revision"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Revision"^^xsd:anyURI ;
+    :unqualifiedForm :wasRevisionOf .
+
+:Role
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Role" ;
+    rdfs:seeAlso :hadRole ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :definition "A role is the function of an entity or agent with respect to an activity, in the context of a usage, generation, invalidation, association, start, and end."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-role"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI .
+
+:SoftwareAgent
+    a owl:Class ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "SoftwareAgent" ;
+    rdfs:subClassOf :Agent ;
+    :category "expanded" ;
+    :component "agents-responsibility" ;
+    :definition "A software agent is running software."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+:Start
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Start provides additional descriptions about the binary prov:wasStartedBy relation from some started prov:Activity to an prov:Entity that started it. For example, :foot_race prov:wasStartedBy :bang; prov:qualifiedStart [ a prov:Start; prov:entity :bang; :foo :bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ] ."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Start" ;
+    rdfs:subClassOf :EntityInfluence, :InstantaneousEvent ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "Start is when an activity is deemed to have been started by an entity, known as trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start. A start may refer to a trigger entity that set off the activity, or to an activity, known as starter, that generated the trigger."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Start"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Start"^^xsd:anyURI ;
+    :unqualifiedForm :wasStartedBy .
+
+:Usage
+    a owl:Class ;
+    rdfs:comment "An instance of prov:Usage provides additional descriptions about the binary prov:used relation from some prov:Activity to an prov:Entity that it used. For example, :keynote prov:used :podium; prov:qualifiedUsage [ a prov:Usage; prov:entity :podium; :foo :bar ]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "Usage" ;
+    rdfs:subClassOf :EntityInfluence, :InstantaneousEvent ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "Usage is the beginning of utilizing an entity by an activity. Before usage, the activity had not begun to utilize this entity and could not have been affected by the entity."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Usage"^^xsd:anyURI ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Usage"^^xsd:anyURI ;
+    :unqualifiedForm :used .
+
+:actedOnBehalfOf
+    a owl:ObjectProperty ;
+    rdfs:comment "An object property to express the accountability of an agent towards another agent. The subordinate agent acted on behalf of the responsible agent in an actual activity. "@en ;
+    rdfs:domain :Agent ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "actedOnBehalfOf" ;
+    rdfs:range :Agent ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedDelegation
+        :agent
+    ) ;
+    :category "starting-point" ;
+    :component "agents-responsibility" ;
+    :inverse "hadDelegate" ;
+    :qualifiedForm :Delegation, :qualifiedDelegation .
+
+:activity
+    a owl:ObjectProperty ;
+    rdfs:domain :ActivityInfluence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "activity" ;
+    rdfs:range :Activity ;
+    rdfs:subPropertyOf :influencer ;
+    :category "qualified" ;
+    :editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+    :editorsDefinition "The prov:activity property references an prov:Activity which influenced a resource. This property applies to an prov:ActivityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
+    :inverse "activityOfInfluence" .
+
+:agent
+    a owl:ObjectProperty ;
+    rdfs:domain :AgentInfluence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "agent" ;
+    rdfs:range :Agent ;
+    rdfs:subPropertyOf :influencer ;
+    :category "qualified" ;
+    :editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+    :editorsDefinition "The prov:agent property references an prov:Agent which influenced a resource. This property applies to an prov:AgentInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent."@en ;
+    :inverse "agentOfInfluence" .
+
+:alternateOf
+    a owl:ObjectProperty ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "alternateOf" ;
+    rdfs:range :Entity ;
+    rdfs:seeAlso :specializationOf ;
+    :category "expanded" ;
+    :component "alternate" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "Two alternate entities present aspects of the same thing. These aspects may be the same or different, and the alternate entities may or may not overlap in time."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-alternate"^^xsd:anyURI ;
+    :inverse "alternateOf" ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-alternate"^^xsd:anyURI .
+
+:aq
+    a owl:AnnotationProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+:atLocation
+    a owl:ObjectProperty ;
+    rdfs:comment "The Location of any resource."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            :Agent
+            :Entity
+            :InstantaneousEvent
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "atLocation" ;
+    rdfs:range :Location ;
+    :category "expanded" ;
+    :editorialNote "The naming of prov:atLocation parallels prov:atTime, and is not named prov:hadLocation to avoid conflicting with the convention that prov:had* properties are used on prov:Influence classes."@en, "This property is not functional because the many values could be at a variety of granularies (In this building, in this room, in that chair)."@en ;
+    :inverse "locationOf" ;
+    :sharesDefinitionWith :Location .
+
+:atTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an InstantaneousEvent occurred, in the form of xsd:dateTime."@en ;
+    rdfs:domain :InstantaneousEvent ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "atTime" ;
+    rdfs:range xsd:dateTime ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :sharesDefinitionWith :InstantaneousEvent ;
+    :unqualifiedForm :endedAtTime, :generatedAtTime, :invalidatedAtTime, :startedAtTime .
+
+:category
+    a owl:AnnotationProperty ;
+    rdfs:comment "Classify prov-o terms into three categories, including 'starting-point', 'qualifed', and 'extended'. This classification is used by the prov-o html document to gently introduce prov-o terms to its users. "@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+:component
+    a owl:AnnotationProperty ;
+    rdfs:comment "Classify prov-o terms into six components according to prov-dm, including 'agents-responsibility', 'alternate', 'annotations', 'collections', 'derivations', and 'entities-activities'. This classification is used so that readers of prov-o specification can find its correspondence with the prov-dm specification."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+:constraints
+    a owl:AnnotationProperty ;
+    rdfs:comment "A reference to the principal section of the PROV-CONSTRAINTS document that describes this concept."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+:definition
+    a owl:AnnotationProperty ;
+    rdfs:comment "A definition quoted from PROV-DM or PROV-CONSTRAINTS that describes the concept expressed with this OWL term."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+:dm
+    a owl:AnnotationProperty ;
+    rdfs:comment "A reference to the principal section of the PROV-DM document that describes this concept."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+:editorialNote
+    a owl:AnnotationProperty ;
+    rdfs:comment "A note by the OWL development team about how this term expresses the PROV-DM concept, or how it should be used in context of semantic web or linked data."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+:editorsDefinition
+    a owl:AnnotationProperty ;
+    rdfs:comment "When the prov-o term does not have a definition drawn from prov-dm, and the prov-o editor provides one."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf :definition .
+
+:endedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an activity ended. See also prov:startedAtTime."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "endedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    :category "starting-point" ;
+    :component "entities-activities" ;
+    :editorialNote "It is the intent that the property chain holds: (prov:qualifiedEnd o prov:atTime) rdfs:subPropertyOf prov:endedAtTime."@en ;
+    :qualifiedForm :End, :atTime .
+
+:entity
+    a owl:ObjectProperty ;
+    rdfs:domain :EntityInfluence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "entity" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :influencer ;
+    :category "qualified" ;
+    :editorialNote "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+    :editorsDefinition "The prov:entity property references an prov:Entity which influenced a resource. This property applies to an prov:EntityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
+    :inverse "entityOfInfluence" .
+
+:generated
+    a owl:ObjectProperty ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "generated" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :influenced ;
+    owl:inverseOf :wasGeneratedBy ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :editorialNote "prov:generated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
+    :inverse "wasGeneratedBy" ;
+    :sharesDefinitionWith :Generation .
+
+:generatedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an entity was completely created and is available for use."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "generatedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :editorialNote "It is the intent that the property chain holds: (prov:qualifiedGeneration o prov:atTime) rdfs:subPropertyOf prov:generatedAtTime."@en ;
+    :qualifiedForm :Generation, :atTime .
+
+:hadActivity
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Activity of an Influence, which used, generated, invalidated, or was the responsibility of some Entity. This property is _not_ used by ActivityInfluence (use prov:activity instead)."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain :Influence, [
+        a owl:Class ;
+        owl:unionOf (:Delegation
+            :Derivation
+            :End
+            :Start
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadActivity" ;
+    rdfs:range :Activity ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :editorialNote "The multiple rdfs:domain assertions are intended. One is simpler and works for OWL-RL, the union is more specific but is not recognized by OWL-RL."@en ;
+    :inverse "wasActivityOfInfluence" ;
+    :sharesDefinitionWith :Activity .
+
+:hadGeneration
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Generation involved in an Entity's Derivation."@en ;
+    rdfs:domain :Derivation ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadGeneration" ;
+    rdfs:range :Generation ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :inverse "generatedAsDerivation" ;
+    :sharesDefinitionWith :Generation .
+
+:hadMember
+    a owl:ObjectProperty ;
+    rdfs:domain :Collection ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadMember" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    :category "expanded" ;
+    :component "expanded" ;
+    :inverse "wasMemberOf" ;
+    :sharesDefinitionWith :Collection .
+
+:hadPlan
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Plan adopted by an Agent in Association with some Activity. Plan specifications are out of the scope of this specification."@en ;
+    rdfs:domain :Association ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadPlan" ;
+    rdfs:range :Plan ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :inverse "wasPlanOf" ;
+    :sharesDefinitionWith :Plan .
+
+:hadPrimarySource
+    a owl:ObjectProperty ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadPrimarySource" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasDerivedFrom ;
+    owl:propertyChainAxiom (:qualifiedPrimarySource
+        :entity
+    ) ;
+    :category "expanded" ;
+    :component "derivations" ;
+    :inverse "wasPrimarySourceOf" ;
+    :qualifiedForm :PrimarySource, :qualifiedPrimarySource .
+
+:hadRole
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Role that an Entity assumed in the context of an Activity. For example, :baking prov:used :spoon; prov:qualified [ a prov:Usage; prov:entity :spoon; prov:hadRole roles:mixing_implement ]."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain :Influence, [
+        a owl:Class ;
+        owl:unionOf (:Association
+            :InstantaneousEvent
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadRole" ;
+    rdfs:range :Role ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :editorsDefinition "prov:hadRole references the Role (i.e. the function of an entity with respect to an activity), in the context of an instantaneous usage, generation, association, start, and end."@en ;
+    :inverse "wasRoleIn" ;
+    :sharesDefinitionWith :Role .
+
+:hadUsage
+    a owl:ObjectProperty ;
+    rdfs:comment "The _optional_ Usage involved in an Entity's Derivation."@en ;
+    rdfs:domain :Derivation ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "hadUsage" ;
+    rdfs:range :Usage ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :inverse "wasUsedInDerivation" ;
+    :sharesDefinitionWith :Usage .
+
+:influenced
+    a owl:ObjectProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "influenced" ;
+    owl:inverseOf :wasInfluencedBy ;
+    :category "expanded" ;
+    :component "agents-responsibility" ;
+    :inverse "wasInfluencedBy" ;
+    :sharesDefinitionWith :Influence .
+
+:influencer
+    a owl:ObjectProperty ;
+    rdfs:comment "Subproperties of prov:influencer are used to cite the object of an unqualified PROV-O triple whose predicate is a subproperty of prov:wasInfluencedBy (e.g. prov:used, prov:wasGeneratedBy). prov:influencer is used much like rdf:object is used."@en ;
+    rdfs:domain :Influence ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "influencer" ;
+    rdfs:range owl:Thing ;
+    :category "qualified" ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
+    :editorialNote "This property and its subproperties are used in the same way as the rdf:object property, i.e. to reference the object of an unqualified prov:wasInfluencedBy or prov:influenced triple."@en ;
+    :editorsDefinition "This property is used as part of the qualified influence pattern. Subclasses of prov:Influence use these subproperties to reference the resource (Entity, Agent, or Activity) whose influence is being qualified."@en ;
+    :inverse "hadInfluence" .
+
+:invalidated
+    a owl:ObjectProperty ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "invalidated" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :influenced ;
+    owl:inverseOf :wasInvalidatedBy ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :editorialNote "prov:invalidated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
+    :inverse "wasInvalidatedBy" ;
+    :sharesDefinitionWith :Invalidation .
+
+:invalidatedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an entity was invalidated (i.e., no longer usable)."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "invalidatedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :editorialNote "It is the intent that the property chain holds: (prov:qualifiedInvalidation o prov:atTime) rdfs:subPropertyOf prov:invalidatedAtTime."@en ;
+    :qualifiedForm :Invalidation, :atTime .
+
+:inverse
+    a owl:AnnotationProperty ;
+    rdfs:comment "PROV-O does not define all property inverses. The directionalities defined in PROV-O should be given preference over those not defined. However, if users wish to name the inverse of a PROV-O property, the local name given by prov:inverse should be used."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:seeAlso <http://www.w3.org/TR/prov-o/#names-of-inverse-properties> .
+
+:n
+    a owl:AnnotationProperty ;
+    rdfs:comment "A reference to the principal section of the PROV-DM document that describes this concept."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+:order
+    a owl:AnnotationProperty ;
+    rdfs:comment "The position that this OWL term should be listed within documentation. The scope of the documentation (e.g., among all terms, among terms within a prov:category, among properties applying to a particular class, etc.) is unspecified."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> .
+
+:qualifiedAssociation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasAssociatedWith Agent :ag, then it can qualify the Association using prov:qualifiedAssociation [ a prov:Association;  prov:agent :ag; :foo :bar ]."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedAssociation" ;
+    rdfs:range :Association ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :inverse "qualifiedAssociationOf" ;
+    :sharesDefinitionWith :Association ;
+    :unqualifiedForm :wasAssociatedWith .
+
+:qualifiedAttribution
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasAttributedTo Agent :ag, then it can qualify how it was influenced using prov:qualifiedAttribution [ a prov:Attribution;  prov:agent :ag; :foo :bar ]."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedAttribution" ;
+    rdfs:range :Attribution ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :inverse "qualifiedAttributionOf" ;
+    :sharesDefinitionWith :Attribution ;
+    :unqualifiedForm :wasAttributedTo .
+
+:qualifiedCommunication
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasInformedBy Activity :a, then it can qualify how it was influenced using prov:qualifiedCommunication [ a prov:Communication;  prov:activity :a; :foo :bar ]."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedCommunication" ;
+    rdfs:range :Communication ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :inverse "qualifiedCommunicationOf" ;
+    :qualifiedForm :Communication ;
+    :sharesDefinitionWith :Communication .
+
+:qualifiedDelegation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Agent prov:actedOnBehalfOf Agent :ag, then it can qualify how with prov:qualifiedResponsibility [ a prov:Responsibility;  prov:agent :ag; :foo :bar ]."@en ;
+    rdfs:domain :Agent ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedDelegation" ;
+    rdfs:range :Delegation ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :inverse "qualifiedDelegationOf" ;
+    :sharesDefinitionWith :Delegation ;
+    :unqualifiedForm :actedOnBehalfOf .
+
+:qualifiedDerivation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasDerivedFrom Entity :e, then it can qualify how it was derived using prov:qualifiedDerivation [ a prov:Derivation;  prov:entity :e; :foo :bar ]."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedDerivation" ;
+    rdfs:range :Derivation ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :inverse "qualifiedDerivationOf" ;
+    :sharesDefinitionWith :Derivation ;
+    :unqualifiedForm :wasDerivedFrom .
+
+:qualifiedEnd
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasEndedBy Entity :e1, then it can qualify how it was ended using prov:qualifiedEnd [ a prov:End;  prov:entity :e1; :foo :bar ]."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedEnd" ;
+    rdfs:range :End ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :inverse "qualifiedEndOf" ;
+    :sharesDefinitionWith :End ;
+    :unqualifiedForm :wasEndedBy .
+
+:qualifiedForm
+    a owl:AnnotationProperty ;
+    rdfs:comment """This annotation property links a subproperty of prov:wasInfluencedBy with the subclass of prov:Influence and the qualifying property that are used to qualify it. 
+
+Example annotation:
+
+    prov:wasGeneratedBy prov:qualifiedForm prov:qualifiedGeneration, prov:Generation .
+
+Then this unqualified assertion:
+
+    :entity1 prov:wasGeneratedBy :activity1 .
+
+can be qualified by adding:
+
+   :entity1 prov:qualifiedGeneration :entity1Gen .
+   :entity1Gen 
+       a prov:Generation, prov:Influence;
+       prov:activity :activity1;
+       :customValue 1337 .
+
+Note how the value of the unqualified influence (prov:wasGeneratedBy :activity1) is mirrored as the value of the prov:activity (or prov:entity, or prov:agent) property on the influence class."""@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+:qualifiedGeneration
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:generated Entity :e, then it can qualify how it performed the Generation using prov:qualifiedGeneration [ a prov:Generation;  prov:entity :e; :foo :bar ]."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedGeneration" ;
+    rdfs:range :Generation ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :inverse "qualifiedGenerationOf" ;
+    :sharesDefinitionWith :Generation ;
+    :unqualifiedForm :wasGeneratedBy .
+
+:qualifiedInfluence
+    a owl:ObjectProperty ;
+    rdfs:comment "Because prov:qualifiedInfluence is a broad relation, the more specific relations (qualifiedCommunication, qualifiedDelegation, qualifiedEnd, etc.) should be used when applicable."@en ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            :Agent
+            :Entity
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedInfluence" ;
+    rdfs:range :Influence ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :inverse "qualifiedInfluenceOf" ;
+    :sharesDefinitionWith :Influence ;
+    :unqualifiedForm :wasInfluencedBy .
+
+:qualifiedInvalidation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasInvalidatedBy Activity :a, then it can qualify how it was invalidated using prov:qualifiedInvalidation [ a prov:Invalidation;  prov:activity :a; :foo :bar ]."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedInvalidation" ;
+    rdfs:range :Invalidation ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :inverse "qualifiedInvalidationOf" ;
+    :sharesDefinitionWith :Invalidation ;
+    :unqualifiedForm :wasInvalidatedBy .
+
+:qualifiedPrimarySource
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:hadPrimarySource Entity :e, then it can qualify how using prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :e; :foo :bar ]."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedPrimarySource" ;
+    rdfs:range :PrimarySource ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :inverse "qualifiedSourceOf" ;
+    :sharesDefinitionWith :PrimarySource ;
+    :unqualifiedForm :hadPrimarySource .
+
+:qualifiedQuotation
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasQuotedFrom Entity :e, then it can qualify how using prov:qualifiedQuotation [ a prov:Quotation;  prov:entity :e; :foo :bar ]."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedQuotation" ;
+    rdfs:range :Quotation ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :inverse "qualifiedQuotationOf" ;
+    :sharesDefinitionWith :Quotation ;
+    :unqualifiedForm :wasQuotedFrom .
+
+:qualifiedRevision
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Entity prov:wasRevisionOf Entity :e, then it can qualify how it was revised using prov:qualifiedRevision [ a prov:Revision;  prov:entity :e; :foo :bar ]."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedRevision" ;
+    rdfs:range :Revision ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "derivations" ;
+    :inverse "revisedEntity" ;
+    :sharesDefinitionWith :Revision ;
+    :unqualifiedForm :wasRevisionOf .
+
+:qualifiedStart
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:wasStartedBy Entity :e1, then it can qualify how it was started using prov:qualifiedStart [ a prov:Start;  prov:entity :e1; :foo :bar ]."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedStart" ;
+    rdfs:range :Start ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :inverse "qualifiedStartOf" ;
+    :sharesDefinitionWith :Start ;
+    :unqualifiedForm :wasStartedBy .
+
+:qualifiedUsage
+    a owl:ObjectProperty ;
+    rdfs:comment "If this Activity prov:used Entity :e, then it can qualify how it used it using prov:qualifiedUsage [ a prov:Usage; prov:entity :e; :foo :bar ]."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "qualifiedUsage" ;
+    rdfs:range :Usage ;
+    rdfs:subPropertyOf :qualifiedInfluence ;
+    :category "qualified" ;
+    :component "entities-activities" ;
+    :inverse "qualifiedUsingActivity" ;
+    :sharesDefinitionWith :Usage ;
+    :unqualifiedForm :used .
+
+:sharesDefinitionWith
+    a owl:AnnotationProperty ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+:specializationOf
+    a owl:AnnotationProperty, owl:ObjectProperty ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "specializationOf" ;
+    rdfs:range :Entity ;
+    rdfs:seeAlso :alternateOf ;
+    rdfs:subPropertyOf :alternateOf ;
+    :category "expanded" ;
+    :component "alternate" ;
+    :constraints "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+    :definition "An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-specialization"^^xsd:anyURI ;
+    :inverse "generalizationOf" ;
+    :n "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-specialization"^^xsd:anyURI .
+
+:startedAtTime
+    a owl:DatatypeProperty ;
+    rdfs:comment "The time at which an activity started. See also prov:endedAtTime."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "startedAtTime" ;
+    rdfs:range xsd:dateTime ;
+    :category "starting-point" ;
+    :component "entities-activities" ;
+    :editorialNote "It is the intent that the property chain holds: (prov:qualifiedStart o prov:atTime) rdfs:subPropertyOf prov:startedAtTime."@en ;
+    :qualifiedForm :Start, :atTime .
+
+:todo
+    a owl:AnnotationProperty .
+
+:unqualifiedForm
+    a owl:AnnotationProperty ;
+    rdfs:comment "Classes and properties used to qualify relationships are annotated with prov:unqualifiedForm to indicate the property used to assert an unqualified provenance relation."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:subPropertyOf rdfs:seeAlso .
+
+:used
+    a owl:ObjectProperty ;
+    rdfs:comment "A prov:Entity that was used by this prov:Activity. For example, :baking prov:used :spoon, :egg, :oven ."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "used" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedUsage
+        :entity
+    ) ;
+    :category "starting-point" ;
+    :component "entities-activities" ;
+    :inverse "wasUsedBy" ;
+    :qualifiedForm :Usage, :qualifiedUsage .
+
+:value
+    a owl:DatatypeProperty ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "value" ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :definition "Provides a value that is a direct representation of an entity."@en ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-value"^^xsd:anyURI ;
+    :editorialNote "The editor's definition comes from http://www.w3.org/TR/rdf-primer/#rdfvalue", "This property serves the same purpose as rdf:value, but has been reintroduced to avoid some of the definitional ambiguity in the RDF specification (specifically, 'may be used in describing structured values')."@en .
+
+:wasAssociatedWith
+    a owl:ObjectProperty ;
+    rdfs:comment "An prov:Agent that had some (unspecified) responsibility for the occurrence of this prov:Activity."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasAssociatedWith" ;
+    rdfs:range :Agent ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedAssociation
+        :agent
+    ) ;
+    :category "starting-point" ;
+    :component "agents-responsibility" ;
+    :inverse "wasAssociateFor" ;
+    :qualifiedForm :Association, :qualifiedAssociation .
+
+:wasAttributedTo
+    a owl:ObjectProperty ;
+    rdfs:comment "Attribution is the ascribing of an entity to an agent."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasAttributedTo" ;
+    rdfs:range :Agent ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedAttribution
+        :agent
+    ) ;
+    :category "starting-point" ;
+    :component "agents-responsibility" ;
+    :definition "Attribution is the ascribing of an entity to an agent."@en ;
+    :inverse "contributed" ;
+    :qualifiedForm :Attribution, :qualifiedAttribution .
+
+:wasDerivedFrom
+    a owl:ObjectProperty ;
+    rdfs:comment "The more specific subproperties of prov:wasDerivedFrom (i.e., prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource) should be used when applicable."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasDerivedFrom" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedDerivation
+        :entity
+    ) ;
+    :category "starting-point" ;
+    :component "derivations" ;
+    :definition "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
+    :inverse "hadDerivation" ;
+    :qualifiedForm :Derivation, :qualifiedDerivation .
+
+:wasEndedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "End is when an activity is deemed to have ended. An end may refer to an entity, known as trigger, that terminated the activity."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasEndedBy" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedEnd
+        :entity
+    ) ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :inverse "ended" ;
+    :qualifiedForm :End, :qualifiedEnd .
+
+:wasGeneratedBy
+    a owl:ObjectProperty ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasGeneratedBy" ;
+    rdfs:range :Activity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedGeneration
+        :activity
+    ) ;
+    :category "starting-point" ;
+    :component "entities-activities" ;
+    :inverse "generated" ;
+    :qualifiedForm :Generation, :qualifiedGeneration .
+
+:wasInfluencedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "Because prov:wasInfluencedBy is a broad relation, its more specific subproperties (e.g. prov:wasInformedBy, prov:actedOnBehalfOf, prov:wasEndedBy, etc.) should be used when applicable."@en, "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            :Agent
+            :Entity
+        )
+    ] ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasInfluencedBy" ;
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            :Agent
+            :Entity
+        )
+    ] ;
+    :category "qualified" ;
+    :component "agents-responsibility" ;
+    :editorialNote """The sub-properties of prov:wasInfluencedBy can be elaborated in more detail using the Qualification Pattern. For example, the binary relation :baking prov:used :spoon can be qualified by asserting :baking prov:qualifiedUsage [ a prov:Usage; prov:entity :spoon; prov:atLocation :kitchen ] .
+
+Subproperties of prov:wasInfluencedBy may also be asserted directly without being qualified.
+
+prov:wasInfluencedBy should not be used without also using one of its subproperties. 
+"""@en ;
+    :inverse "influenced" ;
+    :qualifiedForm :Influence, :qualifiedInfluence ;
+    :sharesDefinitionWith :Influence .
+
+:wasInformedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "An activity a2 is dependent on or informed by another activity a1, by way of some unspecified entity that is generated by a1 and used by a2."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasInformedBy" ;
+    rdfs:range :Activity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedCommunication
+        :activity
+    ) ;
+    :category "starting-point" ;
+    :component "entities-activities" ;
+    :inverse "informed" ;
+    :qualifiedForm :Communication, :qualifiedCommunication .
+
+:wasInvalidatedBy
+    a owl:ObjectProperty ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasInvalidatedBy" ;
+    rdfs:range :Activity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedInvalidation
+        :activity
+    ) ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :inverse "invalidated" ;
+    :qualifiedForm :Invalidation, :qualifiedInvalidation .
+
+:wasQuotedFrom
+    a owl:ObjectProperty ;
+    rdfs:comment "An entity is derived from an original entity by copying, or 'quoting', some or all of it."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasQuotedFrom" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasDerivedFrom ;
+    owl:propertyChainAxiom (:qualifiedQuotation
+        :entity
+    ) ;
+    :category "expanded" ;
+    :component "derivations" ;
+    :inverse "quotedAs" ;
+    :qualifiedForm :Quotation, :qualifiedQuotation .
+
+:wasRevisionOf
+    a owl:AnnotationProperty, owl:ObjectProperty ;
+    rdfs:comment "A revision is a derivation that revises an entity into a revised version."@en ;
+    rdfs:domain :Entity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasRevisionOf" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasDerivedFrom ;
+    owl:propertyChainAxiom (:qualifiedRevision
+        :entity
+    ) ;
+    :category "expanded" ;
+    :component "derivations" ;
+    :inverse "hadRevision" ;
+    :qualifiedForm :Revision, :qualifiedRevision .
+
+:wasStartedBy
+    a owl:ObjectProperty ;
+    rdfs:comment "Start is when an activity is deemed to have started. A start may refer to an entity, known as trigger, that initiated the activity."@en ;
+    rdfs:domain :Activity ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/prov-o#> ;
+    rdfs:label "wasStartedBy" ;
+    rdfs:range :Entity ;
+    rdfs:subPropertyOf :wasInfluencedBy ;
+    owl:propertyChainAxiom (:qualifiedStart
+        :entity
+    ) ;
+    :category "expanded" ;
+    :component "entities-activities" ;
+    :inverse "started" ;
+    :qualifiedForm :Start, :qualifiedStart .
+
+<http://www.w3.org/ns/prov-o#>
+    a owl:Ontology ;
+    rdfs:comment """This document is published by the Provenance Working Group (http://www.w3.org/2011/prov/wiki/Main_Page). 
+
+If you wish to make comments regarding this document, please send them to public-prov-comments@w3.org (subscribe public-prov-comments-request@w3.org, archives http://lists.w3.org/Archives/Public/public-prov-comments/). All feedback is welcome."""@en ;
+    rdfs:label "W3C PROVenance Interchange Ontology (PROV-O)"@en ;
+    rdfs:seeAlso <http://www.w3.org/TR/prov-o/>, <http://www.w3.org/ns/prov> ;
+    owl:versionIRI <http://www.w3.org/ns/prov-o-20130430> ;
+    owl:versionInfo "Recommendation version 2013-04-30"@en ;
+    :specializationOf <http://www.w3.org/ns/prov-o> ;
+    :wasRevisionOf <http://www.w3.org/ns/prov-o-20130312> .
+
+[]
+    a owl:Axiom ;
+    rdfs:comment "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
+    owl:annotatedProperty rdfs:range ;
+    owl:annotatedSource :hadMember ;
+    owl:annotatedTarget :Entity ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection" .
+
+[]
+    a owl:Axiom ;
+    rdfs:comment "hadPrimarySource property is a particular case of wasDerivedFrom (see http://www.w3.org/TR/prov-dm/#term-original-source) that aims to give credit to the source that originated some information." ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource :hadPrimarySource ;
+    owl:annotatedTarget :wasDerivedFrom .
+
+[]
+    a owl:Axiom ;
+    rdfs:comment "Attribution is a particular case of trace (see http://www.w3.org/TR/prov-dm/#concept-trace), in the sense that it links an entity to the agent that ascribed it." ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource :wasAttributedTo ;
+    owl:annotatedTarget :wasInfluencedBy ;
+    :definition "IF wasAttributedTo(e2,ag1,aAttr) holds, THEN wasInfluencedBy(e2,ag1) also holds. " .
+
+[]
+    a owl:Axiom ;
+    rdfs:comment "Derivation is a particular case of trace (see http://www.w3.org/TR/prov-dm/#term-trace), since it links an entity to another entity that contributed to its existence." ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource :wasDerivedFrom ;
+    owl:annotatedTarget :wasInfluencedBy .
+
+[]
+    a owl:Axiom ;
+    owl:annotatedProperty rdfs:range ;
+    owl:annotatedSource :wasInfluencedBy ;
+    owl:annotatedTarget [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            :Agent
+            :Entity
+        )
+    ] ;
+    :definition "influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;" ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence" .
+
+[]
+    a owl:Axiom ;
+    owl:annotatedProperty rdfs:domain ;
+    owl:annotatedSource :wasInfluencedBy ;
+    owl:annotatedTarget [
+        a owl:Class ;
+        owl:unionOf (:Activity
+            :Agent
+            :Entity
+        )
+    ] ;
+    :definition "influencee: an identifier (o2) for an entity, activity, or agent; " ;
+    :dm "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence" .
+
+[]
+    a owl:Axiom ;
+    rdfs:comment "Quotation is a particular case of derivation (see http://www.w3.org/TR/prov-dm/#term-quotation) in which an entity is derived from an original entity by copying, or \"quoting\", some or all of it. " ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource :wasQuotedFrom ;
+    owl:annotatedTarget :wasDerivedFrom .
+
+[]
+    a owl:Axiom ;
+    rdfs:comment """Revision is a derivation (see http://www.w3.org/TR/prov-dm/#term-Revision). Moreover, according to 
+http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#term-Revision 23 April 2012 'wasRevisionOf is a strict sub-relation of wasDerivedFrom since two entities e2 and e1 may satisfy wasDerivedFrom(e2,e1) without being a variant of each other.'""" ;
+    owl:annotatedProperty rdfs:subPropertyOf ;
+    owl:annotatedSource :wasRevisionOf ;
+    owl:annotatedTarget :wasDerivedFrom .
+

--- a/ontology/imports/sosa-prov.ttl
+++ b/ontology/imports/sosa-prov.ttl
@@ -1,0 +1,117 @@
+# baseURI: http://www.w3.org/ns/sosa/prov
+# imports: http://www.w3.org/ns/prov-o#
+# imports: http://www.w3.org/ns/sosa/
+
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix sp: <http://www.w3.org/ns/sosa/prov/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+sosa:Actuation
+  rdfs:subClassOf prov:Activity ;
+.
+sosa:Actuator
+  rdfs:subClassOf prov:Agent ;
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:FeatureOfInterest
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:ObservableProperty
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:Observation
+  rdfs:subClassOf prov:Activity ;
+.
+sosa:Platform
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:Procedure
+  rdfs:subClassOf prov:Plan ;
+.
+sosa:Result
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:Sample
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:Sampler
+  rdfs:subClassOf prov:Agent ;
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:Sampling
+  rdfs:subClassOf prov:Activity ;
+.
+sosa:Sensor
+  rdfs:subClassOf prov:Agent ;
+  rdfs:subClassOf prov:Entity ;
+.
+sosa:hasFeatureOfInterest
+  rdfs:subPropertyOf prov:used ;
+.
+sosa:hasResult
+  rdfs:subPropertyOf prov:generated ;
+.
+sosa:isResultOf
+  rdfs:subPropertyOf prov:wasGeneratedBy ;
+.
+sosa:isSampleOf
+  rdfs:subPropertyOf prov:wasDerivedFrom ;
+.
+sosa:madeByActuator
+  rdfs:subPropertyOf prov:wasAssociatedWith ;
+.
+sosa:madeBySampler
+  rdfs:subPropertyOf prov:wasAssociatedWith ;
+.
+sosa:madeBySensor
+  rdfs:subPropertyOf prov:wasAssociatedWith ;
+.
+sosa:prov
+  rdf:type owl:Ontology ;
+  dcterms:created "2016-12-14"^^xsd:date ;
+  dcterms:creator "Simon J D Cox" ;
+  dcterms:creator [
+      rdf:type foaf:Agent ;
+      foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ;
+    ] ;
+  dcterms:license <http://www.opengeospatial.org/ogc/Software> ;
+  dcterms:license <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
+  dcterms:modified "2017-04-13"^^xsd:date ;
+  dcterms:rights "Copyright 2017 W3C/OGC." ;
+  rdfs:comment "Alignment of the the W3C/OGC SOSA Ontology with the W3C PROV-O Ontology"@en ;
+  rdfs:label "Alignment of SOSA with PROV-O"@en ;
+  owl:imports <http://www.w3.org/ns/prov-o#> ;
+  owl:imports sosa: ;
+.
+sp:eventAssociation
+  rdf:type owl:ObjectProperty ;
+  rdfs:domain [
+      rdf:type owl:Class ;
+      owl:unionOf (
+          sosa:Observation
+          sosa:Actuation
+          sosa:Sampling
+        ) ;
+    ] ;
+  rdfs:subPropertyOf prov:qualifiedAssociation ;
+.
+sp:hadProcedure
+  rdf:type owl:ObjectProperty ;
+  rdfs:range sosa:Procedure ;
+  rdfs:subPropertyOf prov:hadPlan ;
+.
+sosa:resultTime
+  rdfs:subPropertyOf prov:endedAtTime ;
+.
+sosa:usedProcedure
+  owl:propertyChainAxiom (
+      sp:eventAssociation
+      sp:hadProcedure
+    ) ;
+.

--- a/ontology/imports/sosa.ttl
+++ b/ontology/imports/sosa.ttl
@@ -1,0 +1,424 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix schema: <http://schema.org/>.
+
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+
+
+foaf:Agent a owl:Class .
+foaf:name a owl:AnnotationProperty .
+voaf:Vocabulary a owl:Class .
+dcterms:title a owl:AnnotationProperty .
+dcterms:description a owl:AnnotationProperty .
+dcterms:rights a owl:AnnotationProperty .
+dcterms:license a owl:AnnotationProperty .
+dcterms:created a owl:AnnotationProperty .
+dcterms:creator a owl:AnnotationProperty .
+skos:definition a owl:AnnotationProperty .
+skos:example a owl:AnnotationProperty .
+skos:note a owl:AnnotationProperty .
+vann:preferredNamespacePrefix a owl:AnnotationProperty .
+vann:preferredNamespaceUri a owl:AnnotationProperty .
+schema:domainIncludes a owl:AnnotationProperty .
+schema:rangeIncludes a owl:AnnotationProperty .
+time:TemporalEntity a owl:Class .
+
+
+sosa: a owl:Ontology , voaf:Vocabulary ;
+  dcterms:title "Sensor, Observation, Sample, and Actuator (SOSA) Ontology"@en ;
+  dcterms:description "This ontology is based on the SSN Ontology by the W3C Semantic Sensor Networks Incubator Group (SSN-XG), together with considerations from the W3C/OGC Spatial Data on the Web Working Group."@en ;
+  dcterms:creator [ a foaf:Agent ; foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ] ;
+  dcterms:rights "Copyright 2017 W3C/OGC." ;
+  dcterms:license <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
+  dcterms:license <http://www.opengeospatial.org/ogc/Software> ;
+  dcterms:created "2017-04-17"^^xsd:date ;
+  vann:preferredNamespacePrefix "sosa" ;
+  vann:preferredNamespaceUri "http://www.w3.org/ns/sosa/" .
+
+
+## Features of interest and Property
+
+sosa:FeatureOfInterest a rdfs:Class ; a owl:Class ;
+  rdfs:label "Feature Of Interest"@en ;
+  skos:definition "The thing whose property is being estimated or calculated in the course of an Observation to arrive at a Result or whose property is being manipulated by an Actuator, or which is being sampled or transformed in an act of Sampling."@en ;
+  rdfs:comment "The thing whose property is being estimated or calculated in the course of an Observation to arrive at a Result or whose property is being manipulated by an Actuator, or which is being sampled or transformed in an act of Sampling."@en ;
+  skos:example "When measuring the height of a tree, the height is the observed ObservableProperty, 20m may be the Result of the Observation, and the tree is the FeatureOfInterest. A window is a FeatureOfInterest for an automatic window control Actuator."@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:ObservableProperty a rdfs:Class , owl:Class ;
+    rdfs:label "Observable Property"@en ;
+    skos:definition "An observable quality (property, characteristic) of a FeatureOfInterest."@en ;
+    rdfs:comment "An observable quality (property, characteristic) of a FeatureOfInterest."@en ;
+    skos:example "The height of a tree, the depth of a water body, or the temperature of a surface are examples of observable properties, while the value of a classic car is not (directly) observable but asserted."@en ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:ActuatableProperty a rdfs:Class , owl:Class ;
+    rdfs:label "Actuatable Property"@en ;
+    skos:definition "An actuatable quality (property, characteristic) of a FeatureOfInterest."@en ;
+    rdfs:comment "An actuatable quality (property, characteristic) of a FeatureOfInterest."@en ;
+    skos:example "A window actuator acts by changing the state between a frame and a window. The ability of the window to be opened and closed is its ActuatableProperty."@en ;
+    rdfs:isDefinedBy sosa: .
+
+
+## Sample 
+
+sosa:Sample a rdfs:Class , owl:Class ;
+  rdfs:label "Sample"@en ;
+  skos:definition "Feature which is intended to be representative of a FeatureOfInterest on which Observations may be made."@en ;
+  rdfs:comment "Feature which is intended to be representative of a FeatureOfInterest on which Observations may be made."@en ;
+  rdfs:comment "Physical samples are sometimes known as 'specimens'."@en ;
+  rdfs:comment "A Sample is the result from an act of Sampling."@en ;
+  rdfs:comment """Samples are artifacts of an observational strategy, and have no significant function outside of their role in the observation process. The characteristics of the samples themselves are of little interest, except perhaps to the manager of a sampling campaign.
+
+A Sample is intended to sample some FatureOfInterest, so there is an expectation of at least one isSampleOf property. However, in some cases the identity, and even the exact type, of the sampled feature may not be known when observations are made using the sampling features."""@en ;
+  skos:example "A 'station' is essentially an identifiable locality where a sensor system or Procedure may be deployed and an observation made. In the context of the observation model, it connotes the 'world in the vicinity of the station', so the observed properties relate to the physical medium at the station, and not to any physical artifact such as a mooring, buoy, benchmark, monument, well, etc."@en ;
+  skos:example "A statistical sample is often designed to be characteristic of an entire population, so that observations can be made regarding the sample that provide a good estimate of the properties of the population."@en ;
+  skos:note "A transient sample, such as a ships-track or flight-line, might be identified and described, but is unlikely to be revisited exactly."@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:hasSample a owl:ObjectProperty ;
+    rdfs:label "has sample"@en ;
+    skos:definition "Relation between a FeatureOfInterest and the Sample used to represent it."@en ;
+    rdfs:comment "Relation between a FeatureOfInterest and the Sample used to represent it."@en ;
+    schema:domainIncludes sosa:FeatureOfInterest ;
+    schema:rangeIncludes sosa:Sample ;
+    owl:inverseOf sosa:isSampleOf ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:isSampleOf a owl:ObjectProperty ;
+    rdfs:label "is sample of"@en ;
+    skos:definition "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of."@en ;
+    rdfs:comment "Relation from a Sample to the FeatureOfInterest that it is intended to be representative of."@en ;
+    schema:domainIncludes sosa:Sample ;
+    schema:rangeIncludes sosa:FeatureOfInterest ;
+    owl:inverseOf sosa:hasSample ;
+    rdfs:isDefinedBy sosa: .
+
+
+## Platform 
+
+sosa:Platform a rdfs:Class , owl:Class ;
+  rdfs:label "Platform"@en ;
+  skos:definition "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
+  rdfs:comment "A Platform is an entity that hosts other entities, particularly Sensors, Actuators, Samplers, and other Platforms."@en ;
+  skos:example "A post, buoy, vehicle, ship, aircraft, satellite, cell-phone, human or animal may act as platforms for (technical or biological) sensors or actuators."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:hosts a owl:ObjectProperty ;
+  rdfs:label "hosts"@en ;
+  skos:definition "Relation between a Platform and a Sensor, Actuator, Sampler, or Platform, hosted or mounted on it."@en ;
+  rdfs:comment "Relation between a Platform and a Sensor, Actuator, Sampler, or Platform, hosted or mounted on it."@en ;
+  schema:domainIncludes sosa:Platform ;
+  schema:rangeIncludes sosa:Actuator ;
+  schema:rangeIncludes sosa:Sensor ;
+  schema:rangeIncludes sosa:Sampler ;
+  schema:rangeIncludes sosa:Platform ;
+  owl:inverseOf sosa:isHostedBy ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:isHostedBy a owl:ObjectProperty ;
+  rdfs:label "is hosted by"@en ;
+  skos:definition "Relation between a Sensor, Actuator, Sampler, or Platform, and the Platform that it is mounted on or hosted by."@en ;
+  rdfs:comment "Relation between a Sensor, Actuator, Sampler, or Platform, and the Platform that it is mounted on or hosted by."@en ;
+  schema:domainIncludes sosa:Actuator ;
+  schema:domainIncludes sosa:Sensor ;
+  schema:domainIncludes sosa:Sampler ;
+  schema:domainIncludes sosa:Platform ;
+  schema:rangeIncludes sosa:Platform ;
+  owl:inverseOf sosa:hosts ;
+  rdfs:isDefinedBy sosa: .
+
+
+## Procedures
+
+sosa:Procedure a rdfs:Class , owl:Class ;
+  rdfs:label "Procedure"@en ;
+  skos:definition "A workflow, protocol, plan, algorithm, or computational method specifying how to make an Observation, create a Sample, or make a change to the state of the world (via an Actuator). A Procedure is re-usable, and might be involved in many Observations, Samplings, or Actuations. It explains the steps to be carried out to arrive at reproducible results."@en ;
+  rdfs:comment "A workflow, protocol, plan, algorithm, or computational method specifying how to make an Observation, create a Sample, or make a change to the state of the world (via an Actuator). A Procedure is re-usable, and might be involved in many Observations, Samplings, or Actuations. It explains the steps to be carried out to arrive at reproducible results."@en ;
+  skos:example "The measured wind speed differs depending on the height of the sensor above the surface, e.g., due to friction. Consequently, procedures for measuring wind speed define a standard height for anemometers above ground, typically 10m for meteorological measures and 2m in Agrometeorology. This definition of height, sensor placement, and so forth are defined by the Procedure."@en ;
+  skos:note "Many observations may be created via the same Procedure, the same way as many tables are assembled using the same instructions (as information objects, not their concrete realization)."@en ;
+  rdfs:isDefinedBy sosa: .
+
+## ProcedureExecutors
+
+sosa:Sensor a rdfs:Class , owl:Class ;
+  rdfs:label "Sensor"@en ;
+  skos:definition "Device, agent (including humans), or software (simulation) involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
+  rdfs:comment "Device, agent (including humans), or software (simulation) involved in, or implementing, a Procedure. Sensors respond to a stimulus, e.g., a change in the environment, or input data composed from the results of prior Observations, and generate a Result. Sensors can be hosted by Platforms."@en ;
+  skos:example "Accelerometers, gyroscopes, barometers, magnetometers, and so forth are Sensors that are typically mounted on a modern smart phone (which acts as Platform). Other examples of sensors include the human eyes."@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:observes a owl:ObjectProperty ;
+    rdfs:label "observes"@en ;
+    skos:definition "Relation between a Sensor and an ObservableProperty that it is capable of sensing."@en ;
+    rdfs:comment "Relation between a Sensor and an ObservableProperty that it is capable of sensing."@en ;
+    schema:domainIncludes sosa:Sensor ;
+    schema:rangeIncludes sosa:ObservableProperty ;
+    owl:inverseOf sosa:isObservedBy ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:isObservedBy a owl:ObjectProperty ;
+    rdfs:label "is observed by"@en ;
+    skos:definition "Relation between an ObservableProperty and the Sensor able to observe it."@en ;
+    rdfs:comment "Relation between an ObservableProperty and the Sensor able to observe it."@en ;
+    schema:domainIncludes sosa:ObservableProperty ;
+    schema:rangeIncludes sosa:Sensor ;
+    owl:inverseOf sosa:observes ;
+    rdfs:isDefinedBy sosa: .
+
+sosa:Actuator a rdfs:Class , owl:Class ;
+  rdfs:label "Actuator"@en ;
+  skos:definition "A device that is used by, or implements, an (Actuation) Procedure that changes the state of the world."@en ;
+  rdfs:comment "A device that is used by, or implements, an (Actuation) Procedure that changes the state of the world."@en ;
+  skos:example "A window actuator for automatic window control, i.e., opening or closing the window."@en ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:Sampler a rdfs:Class , owl:Class ;
+  rdfs:label "Sampler"@en ;
+  skos:definition "A device that is used by, or implements, a Sampling Procedure to create or transform one or more samples."@en ;
+  rdfs:comment "A device that is used by, or implements, a Sampling Procedure to create or transform one or more samples."@en ;
+  skos:example "A ball mill, diamond drill, hammer, hypodermic syringe and needle, image Sensor or a soil auger can all act as sampling devices (i.e., be Samplers). However, sometimes the distinction between the Sampler and the Sensor is not evident, as they are packaged as a unit. A Sampler need not be a physical device."@en ;
+  rdfs:isDefinedBy sosa: .
+
+## ProcedureExecutions
+
+sosa:usedProcedure a owl:ObjectProperty ;
+  rdfs:label "used procedure"@en ;
+  skos:definition "A relation to link to a re-usable Procedure used in making an Observation, an Actuation, or a Sample, typically through a Sensor, Actuator or Sampler."@en ;
+  rdfs:comment "A relation to link to a re-usable Procedure used in making an Observation, an Actuation, or a Sample, typically through a Sensor, Actuator or Sampler."@en ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Sampling ;
+  schema:rangeIncludes sosa:Procedure ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:hasFeatureOfInterest a owl:ObjectProperty ;
+  rdfs:label "has feature of interest"@en ;
+  skos:definition "A relation between an Observation and the entity whose quality was observed, or between an Actuation and the entity whose property was modified, or between an act of Sampling and the entity that was sampled."@en ;
+  rdfs:comment "A relation between an Observation and the entity whose quality was observed, or between an Actuation and the entity whose property was modified, or between an act of Sampling and the entity that was sampled."@en ;
+  skos:example "For example, in an Observation of the weight of a person, the FeatureOfInterest is the person and the property is its weight."@en ;
+  schema:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Sampling ;
+  schema:rangeIncludes sosa:FeatureOfInterest ;
+  schema:rangeIncludes sosa:Sample ;
+  owl:inverseOf sosa:isFeatureOfInterestOf ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:isFeatureOfInterestOf a owl:ObjectProperty ;
+  rdfs:label "is feature of interest of"@en ;
+  skos:definition "A relation between a FeatureOfInterest and an Observation about it, an Actuation acting on it, or an act of Sampling that sampled it."@en ;
+  rdfs:comment "A relation between a FeatureOfInterest and an Observation about it, an Actuation acting on it, or an act of Sampling that sampled it."@en ;
+  schema:domainIncludes sosa:FeatureOfInterest ;
+  schema:domainIncludes sosa:Sample ;
+  schema:rangeIncludes sosa:Observation ;
+  schema:rangeIncludes sosa:Actuation ;
+  schema:rangeIncludes sosa:Sampling ;
+  owl:inverseOf sosa:hasFeatureOfInterest ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:Observation a rdfs:Class , owl:Class ;
+  rdfs:label "Observation"@en ;
+  skos:definition "Act of carrying out an (Observation) Procedure to estimate or calculate a value of a property of a FeatureOfInterest. Links to a Sensor to describe what made the Observation and how; links to an ObservableProperty to describe what the result is an estimate of, and to a FeatureOfInterest to detail what that property was associated with."@en ;
+  rdfs:comment "Act of carrying out an (Observation) Procedure to estimate or calculate a value of a property of a FeatureOfInterest. Links to a Sensor to describe what made the Observation and how; links to an ObservableProperty to describe what the result is an estimate of, and to a FeatureOfInterest to detail what that property was associated with."@en ;
+  skos:example "The activity of estimating the intensity of an Earthquake using the Mercalli intensity scale is an Observation as is measuring the moment magnitude, i.e., the energy released by said earthquake."@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:madeObservation a owl:ObjectProperty ;
+    rdfs:label "made observation"@en ;
+    skos:definition "Relation between a Sensor and an Observation made by the Sensor."@en ;
+    rdfs:comment "Relation between a Sensor and an Observation made by the Sensor."@en ;
+    schema:domainIncludes sosa:Sensor ;
+    schema:rangeIncludes sosa:Observation ;
+    owl:inverseOf sosa:madeBySensor ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:madeBySensor rdf:type owl:ObjectProperty ;
+   rdfs:label "made by sensor"@en ;
+   skos:definition "Relation between an Observation and the Sensor which made the Observation."@en ;
+   rdfs:comment "Relation between an Observation and the Sensor which made the Observation."@en ;
+   schema:domainIncludes sosa:Observation ;
+   schema:rangeIncludes sosa:Sensor ;
+   owl:inverseOf sosa:madeObservation ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:observedProperty a owl:ObjectProperty ;
+    rdfs:label "observed property"@en ;
+    skos:definition "Relation linking an Observation to the property that was observed. The ObservableProperty should be a property of the FeatureOfInterest (linked by hasFeatureOfInterest) of this Observation."@en ;
+    rdfs:comment "Relation linking an Observation to the property that was observed. The ObservableProperty should be a property of the FeatureOfInterest (linked by hasFeatureOfInterest) of this Observation."@en ;
+    schema:domainIncludes sosa:Observation ;
+    schema:rangeIncludes sosa:ObservableProperty ;
+    rdfs:isDefinedBy sosa: .
+
+sosa:Actuation a rdfs:Class , owl:Class ;
+  rdfs:label "Actuation"@en ;
+  skos:definition "An Actuation carries out an (Actuation) Procedure to change the state of the world using an Actuator."@en ;
+  rdfs:comment "An Actuation carries out an (Actuation) Procedure to change the state of the world using an Actuator."@en ;
+  skos:example "The activity of automatically closing a window if the temperature in a room drops below 20 degree Celsius. The activity is the Actuation and the device that closes the window is the Actuator. The Procedure is the rule, plan, or specification that defines the conditions that triggers the Actuation, here a drop in temperature. "@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:madeActuation a owl:ObjectProperty ;
+    rdfs:label "made actuation"@en ;
+    skos:definition "Relation between an Actuator and the Actuation it has made."@en ;
+    rdfs:comment "Relation between an Actuator and the Actuation it has made."@en ;
+    schema:domainIncludes sosa:Actuator ;
+    schema:rangeIncludes sosa:Actuation ;
+    owl:inverseOf sosa:madeByActuator ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:madeByActuator a owl:ObjectProperty ;
+    rdfs:label "made by actuator"@en ;
+    skos:definition "Relation linking an Actuation to the Actuator that made that Actuation."@en ;
+    rdfs:comment "Relation linking an Actuation to the Actuator that made that Actuation."@en ;
+    schema:domainIncludes sosa:Actuation ;
+    schema:rangeIncludes sosa:Actuator ;
+    owl:inverseOf sosa:madeActuation ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:actsOnProperty a owl:ObjectProperty ;
+    rdfs:label "acts on property"@en ;
+    skos:definition "Relation between an Actuation and the property of a FeatureOfInterest it is acting upon."@en ;
+    rdfs:comment "Relation between an Actuation and the property of a FeatureOfInterest it is acting upon."@en ;
+    skos:example "In the activity (Actuation) of automatically closing a window if the temperature in a room drops below 20 degrees Celsius, the property on which the Actuator acts upon is the state of the window as it changes from being open to being closed. "@en ;
+    schema:domainIncludes sosa:Actuation ;
+    schema:rangeIncludes sosa:ActuatableProperty ;
+    owl:inverseOf sosa:isActedOnBy ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:isActedOnBy a owl:ObjectProperty ;
+    rdfs:label "is acted on by"@en ;
+    skos:definition "Relation between an ActuatableProperty of a FeatureOfInterest and an Actuation changing its state."@en ;
+    rdfs:comment "Relation between an ActuatableProperty of a FeatureOfInterest and an Actuation changing its state."@en ;
+    skos:example "In the activity (Actuation) of automatically closing a window if the temperature in a room drops below 20 degrees Celsius, the property on which the Actuator acts upon is the state of the window as it changes from being open to being closed. "@en ;
+    schema:domainIncludes sosa:ActuatableProperty ;
+    schema:rangeIncludes sosa:Actuation ;
+    owl:inverseOf sosa:actsOnProperty ;
+    rdfs:isDefinedBy sosa: .
+
+sosa:Sampling a rdfs:Class , owl:Class ;
+  rdfs:label "Sampling"@en ;
+  skos:definition "An act of Sampling carries out a sampling Procedure to create or transform one or more samples."@en ;
+  rdfs:comment "An act of Sampling carries out a sampling Procedure to create or transform one or more samples."@en ;
+  skos:example "Crushing a rock sample in a ball mill."@en ;
+  skos:example "Digging a pit through a soil sequence."@en ;
+  skos:example "Dividing a field site into quadrants."@en ;
+  skos:example "Drawing blood from a patient."@en ;
+  skos:example "Drilling an observation well."@en ;
+  skos:example "Establishing a station for environmental monitoring."@en ;
+  skos:example "Registering an image of the landscape."@en ;
+  skos:example "Sieving a powder to separate the subset finer than 100-mesh."@en ;
+  skos:example "Selecting a subset of a population."@en ;
+  skos:example "Splitting a piece of drill-core to create two new samples."@en ;
+  skos:example "Taking a diamond-drill core from a rock outcrop."@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:madeSampling a owl:ObjectProperty ;
+    rdfs:label "made sampling"@en ;
+    skos:definition "Relation between a Sampler (sampling device or entity) and the Sampling act it performed."@en ;
+    rdfs:comment "Relation between a Sampler (sampling device or entity) and the Sampling act it performed."@en ;
+    schema:domainIncludes sosa:Sampler ;
+    schema:rangeIncludes sosa:Sampling ;
+    owl:inverseOf sosa:madeBySampler ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:madeBySampler a owl:ObjectProperty ;
+    rdfs:label "made by sampler"@en ;
+    skos:definition "Relation linking an act of Sampling to the Sampler (sampling device or entity) that made it."@en ;
+    rdfs:comment "Relation linking an act of Sampling to the Sampler (sampling device or entity) that made it."@en ;
+    schema:domainIncludes sosa:Sampling ;
+    schema:rangeIncludes sosa:Sampler ;
+    owl:inverseOf sosa:madeSampling ;
+    rdfs:isDefinedBy sosa: .
+
+
+## Result 
+
+sosa:Result a rdfs:Class , owl:Class ;
+  rdfs:label "Result"@en ;
+  skos:definition "The Result of an Observation, Actuation, or act of Sampling. To store an observation's simple result value one can use the hasSimpleResult property."@en ;
+  rdfs:comment "The Result of an Observation, Actuation, or act of Sampling. To store an observation's simple result value one can use the hasSimpleResult property."@en ;
+  skos:example "The value 20 as the height of a certain tree together with the unit, e.g., Meter."@en ;
+  rdfs:isDefinedBy sosa: .
+
+  sosa:hasResult a owl:ObjectProperty ;
+    rdfs:label "has result"@en ;
+    skos:definition "Relation linking an Observation or Actuation or act of Sampling and a Result or Sample."@en ;
+    rdfs:comment "Relation linking an Observation or Actuation or act of Sampling and a Result or Sample."@en ;
+    schema:domainIncludes sosa:Actuation ;
+    schema:domainIncludes sosa:Observation ;
+    schema:domainIncludes sosa:Sampling ;
+    schema:rangeIncludes sosa:Result ;
+    schema:rangeIncludes sosa:Sample ;
+    owl:inverseOf sosa:isResultOf ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:isResultOf a owl:ObjectProperty ;
+    rdfs:label "is result of"@en ;
+    skos:definition "Relation linking a Result to the Observation or Actuation or act of Sampling that created or caused it."@en ;
+    rdfs:comment "Relation linking a Result to the Observation or Actuation or act of Sampling that created or caused it."@en ;
+    schema:domainIncludes sosa:Result ;
+    schema:domainIncludes sosa:Sample ;
+    schema:rangeIncludes sosa:Actuation ;
+    schema:rangeIncludes sosa:Observation ;
+    schema:rangeIncludes sosa:Sampling ;
+    owl:inverseOf sosa:hasResult ;
+    rdfs:isDefinedBy sosa: .
+
+  sosa:hasSimpleResult a owl:DatatypeProperty ;
+    rdfs:label "has simple result"@en ;
+    skos:definition "The simple value of an Observation or Actuation or act of Sampling."@en ;
+    rdfs:comment "The simple value of an Observation or Actuation or act of Sampling."@en ;
+    skos:example "For instance, the values 23 or true."@en ;
+    schema:domainIncludes sosa:Actuation ;
+    schema:domainIncludes sosa:Observation ;
+    schema:domainIncludes sosa:Sampling ;
+    rdfs:isDefinedBy sosa: .
+
+  # for sampling
+
+#  sosa:hasResultingSample a owl:ObjectProperty ;
+#    rdfs:label "has resulting sample"@en ;
+#    skos:definition "Relation linking an act of Sampling and the new Sample created as a result."@en ;
+#    rdfs:comment "Relation linking an act of Sampling and the new Sample created as a result."@en ;
+#    schema:domainIncludes sosa:Sampling ;
+#    schema:rangeIncludes sosa:Sample ;
+#    owl:inverseOf sosa:isSamplingResultOf ;
+#    rdfs:isDefinedBy sosa: .
+
+#  sosa:isSamplingResultOf a owl:ObjectProperty ;
+#    rdfs:label "is sampling result of"@en ;
+#    skos:definition "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
+#    rdfs:comment "Relation linking a Sample to the act of Sampling that created or caused it."@en ;
+#    schema:domainIncludes sosa:Sample ;
+#    schema:rangeIncludes sosa:Sampling ;
+#    owl:inverseOf sosa:hasResultingSample ;
+#    rdfs:isDefinedBy sosa: .
+
+
+sosa:resultTime a owl:DatatypeProperty ;
+  rdfs:label "result time"@en ;
+  skos:definition "The result time is the instant of time when the Observation, Actuation or Sampling activity was completed."@en ;
+  rdfs:comment "The result time is the instant of time when the Observation, Actuation or Sampling activity was completed."@en ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Sampling ;
+  rdfs:range xsd:dateTime ;
+  rdfs:isDefinedBy sosa: .
+
+sosa:phenomenonTime a owl:ObjectProperty ;
+  rdfs:label "phenomenon time"@en ;
+  skos:definition "The time that the Result of an Observation, Actuation or Sampling applies to the FeatureOfInterest. Not necessarily the same as the resultTime. May be an Interval or an Instant, or some other compound TemporalEntity."@en ;
+  rdfs:comment "The time that the Result of an Observation, Actuation or Sampling applies to the FeatureOfInterest. Not necessarily the same as the resultTime. May be an Interval or an Instant, or some other compound TemporalEntity."@en ;
+  schema:domainIncludes sosa:Actuation ;
+  schema:domainIncludes sosa:Observation ;
+  schema:domainIncludes sosa:Sampling ;
+  schema:rangeIncludes time:TemporalEntity ;
+  rdfs:isDefinedBy sosa: .

--- a/ontology/modules/01-entity-systematics.ttl
+++ b/ontology/modules/01-entity-systematics.ttl
@@ -48,7 +48,11 @@ smn:HabitatUnit a owl:Class ;
   rdfs:subClassOf smn:Entity ;
   rdfs:isDefinedBy <https://w3id.org/smn> .
 
-geosparql:Feature rdfs:subClassOf sosa:FeatureOfInterest .
+# The foreign-subject axiom that sat here (geosparql:Feature
+# rdfs:subClassOf sosa:FeatureOfInterest) moved to alignment-main.ttl on
+# 2026-08-13: core modules never assert axioms on terms smn does not own.
+# sosa:hasFeatureOfInterest's upstream range already entails
+# FeatureOfInterest-ness for geosparql fillers where it matters.
 
 smn:GeographicFeature a owl:Class ;
   rdfs:label "Geographic feature"@en ;

--- a/ontology/modules/02-observation-measurement.ttl
+++ b/ontology/modules/02-observation-measurement.ttl
@@ -210,9 +210,15 @@ smn:SamplingEvent a owl:Class ;
   iao:0000115 "A sampling activity that targets a geographic feature, yields a sample, and records a time."@en ;
   rdfs:isDefinedBy <https://w3id.org/smn> .
 
-sosa:FeatureOfInterest sosa:hasSample sosa:Sample .
-sosa:Sample sosa:isResultOf sosa:Sampling .
+# The two class-level property assertions that used to sit here
+# (sosa:FeatureOfInterest sosa:hasSample sosa:Sample; sosa:Sample
+# sosa:isResultOf sosa:Sampling) were removed 2026-08-13: legal OWL 2 DL
+# punning, but they related the class-individuals and said nothing about
+# instances. The intended instance-level semantics already live in the
+# smn:SamplingEvent restrictions above.
 
+# MIREOT-style mirror of the upstream NCBITaxon hierarchy (Oncorhynchus
+# keta under Salmonidae); byte-faithful to the source, not an smn claim.
 obo:NCBITaxon_8018 rdfs:subClassOf obo:NCBITaxon_8015 .
 
 smn:NCBITaxon_8018 a owl:Class ;
@@ -248,9 +254,10 @@ smn:EscapementSurveyEvent a owl:Class ;
   iao:0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementSurveyEvent."@en ;
   dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> .
 
-smn:EscapementMeasurement a owl:Class ;
-  rdfs:label "Escapement measurement"@en ;
+smn:EscapementEstimate a owl:Class ;
+  rdfs:label "Escapement estimate"@en ;
   iao:0000115 "A measurement or estimate of escapement tied to a stock and a survey event."@en ;
+  rdfs:comment "A datum (IAO measurement datum), not an activity: the corresponding survey activity is smn:EscapementSurveyEvent. Renamed from smn:EscapementMeasurement on 2026-08-13 (alignment pass, finding F6) because every other *Measurement class in this module is a subclass of the activity smn:Measurement, and this one is not — the name was the defect, inherited verbatim from gcdfo:EscapementMeasurement, whose hyponym family should be coordinated in the boundary pass."@en ;
   rdfs:subClassOf iao:0000109 ;
   rdfs:isDefinedBy <https://w3id.org/smn> ;
   iao:0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementMeasurement."@en ;

--- a/ontology/modules/06-data-interoperability.ttl
+++ b/ontology/modules/06-data-interoperability.ttl
@@ -13,21 +13,23 @@
   rdfs:comment "Cross-ontology bridge statements for SOSA, I-ADOPT, Darwin Core, RDF Data Cube, and OWL-Time interoperability."@en .
 
 #################################################################
-# Upper-level crosswalk bridges (existing salmon-domain work)
+# Upper-level crosswalk notes
+#
+# The Tier-1 owl:equivalentClass bridges that used to live here were
+# demoted on 2026-08-13 (alignment pass, findings F2/F5/F7): neither
+# I-ADOPT nor TDWG publishes any of them, equating sosa:Observation with
+# dwc:Occurrence and sosa:Sampling with dwc:Event is wrong under any DwC
+# vintage, and iadopt:Property = sosa:Property collides with I-ADOPT's own
+# definition of Property as a characteristic. The advisory (Tier-3)
+# versions live in alignment-main.ttl, the only module permitted to carry
+# foreign-subject mapping statements.
 #################################################################
-
-iadopt:Entity owl:equivalentClass sosa:FeatureOfInterest .
-iadopt:Property owl:equivalentClass sosa:Property .
-
-sosa:Observation owl:equivalentClass dwc:Occurrence .
-sosa:Sampling owl:equivalentClass dwc:Event .
-
-sosa:Sample owl:equivalentClass dwc:MaterialSample ;
-  rdfs:comment "Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows."@en .
 
 sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon data exchange this usually points to a Darwin Core protocol value or a DwC-DP Protocol record, not to an OWL-equivalent class."@en ;
   rdfs:seeAlso dwc:protocol, dwcdp:Protocol .
 
+# Declaration stubs so I-ADOPT terms can be referenced without importing
+# the full I-ADOPT ontology; they add no axioms of smn's own.
 iadopt:Variable a owl:Class .
 iadopt:Constraint a owl:Class .
 iadopt:StatisticalModifier a owl:Class .

--- a/ontology/modules/alignment-main.ttl
+++ b/ontology/modules/alignment-main.ttl
@@ -10,7 +10,7 @@
 
 <https://w3id.org/smn/modules/alignment-main> a owl:Ontology ;
   rdfs:label "Salmon Domain Ontology Alignment Module (main-candidate)"@en ;
-  rdfs:comment "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research)."@en ;
+  rdfs:comment "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research). This is the only module in the default build permitted to carry mapping statements whose subjects are foreign-namespace terms (CONVENTIONS section 5b): each such statement is a reviewed editorial commitment, held at Tier 3 (advisory) unless an upstream body publishes the stronger form — in which case smn imports the upstream alignment (see alignment-upper) instead of restating it."@en ;
   owl:imports <https://w3id.org/smn> .
 
 #################################################################
@@ -19,7 +19,7 @@
 
 smn:SurveyEvent skos:closeMatch <http://www.w3.org/ns/sosa/Sampling> .
 smn:EscapementSurveyEvent skos:closeMatch <http://www.w3.org/ns/sosa/Sampling> .
-smn:EscapementMeasurement skos:closeMatch <http://www.w3.org/ns/sosa/Result> .
+smn:EscapementEstimate skos:closeMatch <http://www.w3.org/ns/sosa/Result> .
 
 smn:ReportingOrManagementStratum skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
 smn:Stock skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
@@ -73,10 +73,32 @@ smn:hasDeme rdfs:subPropertyOf ro:0002351 .
 smn:hasPopulation rdfs:subPropertyOf ro:0002351 .
 
 #################################################################
-# Representation-level bridges
+# Representation-level bridges (foreign-subject, Tier 3 only)
+#
+# Editorial commitments, not upstream-published alignments: no ratified
+# DwC-to-SOSA or I-ADOPT-to-SOSA mapping exists (verified 2026-08-13).
+# The 2026-05-26 TDWG redefinition makes dwc:Occurrence itself an event
+# ("A dwc:Event that establishes the state of a dwc:Organism..."), which
+# is what keeps the Observation link at closeMatch; dwc:Event's own
+# examples span observations, occurrences, captures, and whole surveys,
+# so it is strictly broader than a sampling act — hence broadMatch.
 #################################################################
 
-<http://www.w3.org/ns/sosa/Sampling> skos:closeMatch dwc:Event .
-<http://www.w3.org/ns/sosa/Sample> skos:closeMatch dwc:MaterialEntity .
+<http://www.w3.org/ns/sosa/Sampling> skos:broadMatch dwc:Event .
+<http://www.w3.org/ns/sosa/Sample> skos:closeMatch dwc:MaterialEntity, dwc:MaterialSample .
 <http://www.w3.org/ns/sosa/Observation> skos:closeMatch dwc:Occurrence .
 <http://www.w3.org/ns/sosa/Procedure> skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
+
+# Demoted from module 06's owl:equivalentClass on 2026-08-13 (F5/F7):
+# I-ADOPT publishes no SOSA alignment, and its Property is defined as "a
+# type of a characteristic of the ObjectOfInterest" — a characteristic,
+# not provably equivalent to sosa:Property; Entity likewise.
+<https://w3id.org/iadopt/ont/Entity> skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
+<https://w3id.org/iadopt/ont/Property> skos:closeMatch <http://www.w3.org/ns/sosa/Property> .
+<https://w3id.org/iadopt/ont/Variable> skos:closeMatch <http://www.w3.org/ns/sosa/ObservableProperty> .
+
+# Moved from module 01 on 2026-08-13 (foreign-subject axiom out of the
+# core spine). Reviewed and kept at Tier 1: a GeoSPARQL feature is a
+# thing that can be observed, and the commitment is load-bearing for
+# smn:SamplingEvent's feature-of-interest restriction.
+<http://www.opengis.net/ont/geosparql#Feature> rdfs:subClassOf <http://www.w3.org/ns/sosa/FeatureOfInterest> .

--- a/ontology/modules/alignment-research.ttl
+++ b/ontology/modules/alignment-research.ttl
@@ -37,10 +37,11 @@
 smn:SurveyEvent rdfs:subClassOf prov:Activity ;
   skos:closeMatch <http://www.w3.org/ns/sosa/Sampling> .
 
-smn:EscapementSurveyEvent rdfs:subClassOf prov:Activity, <http://www.w3.org/ns/sosa/Sampling> ;
-  skos:closeMatch <http://www.w3.org/ns/sosa/Sampling> .
+# closeMatch dropped 2026-08-13 (F2): one strongest mapping per pair —
+# the Tier-1 subClassOf below already carries the claim.
+smn:EscapementSurveyEvent rdfs:subClassOf prov:Activity, <http://www.w3.org/ns/sosa/Sampling> .
 
-smn:EscapementMeasurement rdfs:subClassOf <http://www.w3.org/ns/sosa/Result> ;
+smn:EscapementEstimate rdfs:subClassOf <http://www.w3.org/ns/sosa/Result> ;
   skos:closeMatch <http://www.w3.org/ns/sosa/Observation>, <https://w3id.org/iadopt/ont/Variable> .
 
 smn:ReportingOrManagementStratum skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest>, <https://w3id.org/iadopt/ont/Entity> .
@@ -69,7 +70,7 @@ smn:hasObservationResult a owl:ObjectProperty ;
   iao:0000115 "Relates a survey event to a measurement datum/result it produces for salmon assessment workflows."@en ;
   rdfs:subPropertyOf <http://www.w3.org/ns/sosa/hasResult> ;
   rdfs:domain smn:SurveyEvent ;
-  rdfs:range smn:EscapementMeasurement ;
+  rdfs:range smn:EscapementEstimate ;
   rdfs:isDefinedBy <https://w3id.org/smn> ;
   iao:0000119 "GC DFO Salmon Ontology release 0.0.8, term gcdfo:hasObservationResult."@en ;
   dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.8/gcdfo.ttl> .

--- a/ontology/modules/alignment-research.ttl
+++ b/ontology/modules/alignment-research.ttl
@@ -102,9 +102,10 @@ smn:isSampleOfStratum a owl:ObjectProperty ;
 smn:hasDeme rdfs:subPropertyOf ro:0002351 .
 smn:hasPopulation rdfs:subPropertyOf ro:0002351 .
 
-<http://www.w3.org/ns/sosa/Sampling> skos:closeMatch dwc:Event .
-<http://www.w3.org/ns/sosa/Sample> skos:closeMatch dwc:MaterialEntity .
-<http://www.w3.org/ns/sosa/Observation> skos:closeMatch dwc:Occurrence .
-<http://www.w3.org/ns/sosa/Procedure> skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
+# The four representation-level bridges that were duplicated here were
+# removed 2026-08-13: the research build imports the root ontology, which
+# already carries alignment-main's versions (including the demoted
+# sosa:Sampling broadMatch dwc:Event), and duplicating them here published
+# a conflicting closeMatch for the same pair (CONVENTIONS 5b rule 1).
 <http://www.w3.org/ns/sosa/FeatureOfInterest> skos:closeMatch <https://w3id.org/iadopt/ont/Entity> .
 <http://www.w3.org/ns/sosa/ObservableProperty> skos:closeMatch <https://w3id.org/iadopt/ont/Property> .

--- a/ontology/modules/alignment-upper.ttl
+++ b/ontology/modules/alignment-upper.ttl
@@ -1,0 +1,10 @@
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+<https://w3id.org/smn/modules/alignment-upper> a owl:Ontology ;
+  rdfs:label "Salmon Domain Ontology upper alignment (imported W3C alignments)"@en ;
+  rdfs:comment "Normative-core upper alignment. Imports the W3C-published SOSA-to-PROV-O alignment instead of re-asserting its axioms on foreign-namespace terms — the convention this module exists to enforce: smn never states axioms whose subjects it does not own outside a reviewed alignment module, and where an upstream body already publishes the alignment, smn imports it. The SOSA-PROV alignment is non-normative in the SSN Recommendation (2017, section 6.5); smn adopts it as the provenance backbone for the deterministic-reasoning consumption target. Offline and CI loading resolves the import to the vendored snapshot ontology/imports/sosa-prov.ttl via catalog-v001.xml; the snapshot is a byte copy of the W3C file and must not be hand-edited."@en ;
+  owl:imports <http://www.w3.org/ns/sosa/prov> ;
+  rdfs:seeAlso <https://www.w3.org/TR/vocab-ssn/#PROV> ;
+  dcterms:source <http://www.w3.org/ns/sosa/prov> .

--- a/ontology/salmon-domain-ontology.ttl
+++ b/ontology/salmon-domain-ontology.ttl
@@ -18,4 +18,5 @@
     <https://w3id.org/smn/modules/05-provenance-quality>,
     <https://w3id.org/smn/modules/06-data-interoperability>,
     <https://w3id.org/smn/modules/07-controlled-vocabularies>,
-    <https://w3id.org/smn/modules/alignment-main> .
+    <https://w3id.org/smn/modules/alignment-main>,
+    <https://w3id.org/smn/modules/alignment-upper> .

--- a/ontology/views/catalog-v001.xml
+++ b/ontology/views/catalog-v001.xml
@@ -17,6 +17,9 @@
   <uri name="https://w3id.org/smn/modules/08-rda-case-study-profile-bridges" uri="../modules/08-rda-case-study-profile-bridges.ttl"/>
   <uri name="https://w3id.org/smn/modules/09-rda-neville-decomposition-profile-bridges" uri="../modules/09-rda-neville-decomposition-profile-bridges.ttl"/>
   <uri name="http://www.w3.org/ns/sosa/prov" uri="../imports/sosa-prov.ttl"/>
+  <uri name="http://www.w3.org/ns/prov-o#" uri="../imports/prov-o.ttl"/>
+  <uri name="http://www.w3.org/ns/prov-o" uri="../imports/prov-o.ttl"/>
+  <uri name="http://www.w3.org/ns/sosa/" uri="../imports/sosa.ttl"/>
   <uri name="https://w3id.org/smn/views/salmon-data-metamodel" uri="salmon-data-metamodel.ttl"/>
   <uri name="https://w3id.org/smn/views/salmon-data-metamodel/entity" uri="salmon-data-metamodel-entity.ttl"/>
   <uri name="https://w3id.org/smn/views/salmon-data-metamodel/property" uri="salmon-data-metamodel-property.ttl"/>

--- a/ontology/views/catalog-v001.xml
+++ b/ontology/views/catalog-v001.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <!-- Local IRI-to-file resolution for Protégé/ROBOT. Added 2026-08-13
+       (alignment pass F4): before this, only build_flat_smn_ttl.py could
+       resolve module IRIs offline. -->
+  <uri name="https://w3id.org/smn" uri="../salmon-domain-ontology.ttl"/>
+  <uri name="https://w3id.org/smn/modules/01-entity-systematics" uri="../modules/01-entity-systematics.ttl"/>
+  <uri name="https://w3id.org/smn/modules/02-observation-measurement" uri="../modules/02-observation-measurement.ttl"/>
+  <uri name="https://w3id.org/smn/modules/03-assessment-benchmarks" uri="../modules/03-assessment-benchmarks.ttl"/>
+  <uri name="https://w3id.org/smn/modules/04-management-governance" uri="../modules/04-management-governance.ttl"/>
+  <uri name="https://w3id.org/smn/modules/05-provenance-quality" uri="../modules/05-provenance-quality.ttl"/>
+  <uri name="https://w3id.org/smn/modules/06-data-interoperability" uri="../modules/06-data-interoperability.ttl"/>
+  <uri name="https://w3id.org/smn/modules/07-controlled-vocabularies" uri="../modules/07-controlled-vocabularies.ttl"/>
+  <uri name="https://w3id.org/smn/modules/alignment-main" uri="../modules/alignment-main.ttl"/>
+  <uri name="https://w3id.org/smn/modules/alignment-upper" uri="../modules/alignment-upper.ttl"/>
+  <uri name="https://w3id.org/smn/modules/alignment-research" uri="../modules/alignment-research.ttl"/>
+  <uri name="https://w3id.org/smn/modules/08-rda-case-study-profile-bridges" uri="../modules/08-rda-case-study-profile-bridges.ttl"/>
+  <uri name="https://w3id.org/smn/modules/09-rda-neville-decomposition-profile-bridges" uri="../modules/09-rda-neville-decomposition-profile-bridges.ttl"/>
+  <uri name="http://www.w3.org/ns/sosa/prov" uri="../imports/sosa-prov.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel" uri="salmon-data-metamodel.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/entity" uri="salmon-data-metamodel-entity.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/property" uri="salmon-data-metamodel-property.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/variable" uri="salmon-data-metamodel-variable.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/method-protocol" uri="salmon-data-metamodel-method-protocol.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/event-observation" uri="salmon-data-metamodel-event-observation.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/result-datum" uri="salmon-data-metamodel-result-datum.ttl"/>
+  <uri name="https://w3id.org/smn/views/salmon-data-metamodel/provenance" uri="salmon-data-metamodel-provenance.ttl"/>
+</catalog>

--- a/ontology/views/salmon-data-metamodel-entity.ttl
+++ b/ontology/views/salmon-data-metamodel-entity.ttl
@@ -7,14 +7,9 @@
 
 <https://w3id.org/smn/views/salmon-data-metamodel/entity> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view — entity slice"@en ;
-  rdfs:comment "Simple entity slice: what the data is about."@en .
+  rdfs:comment "Simple entity slice: what the data is about. Statements here have smn-owned subjects only; the iadopt/sosa bridge (iadopt:Entity closeMatch sosa:FeatureOfInterest) lives in alignment-main."@en .
 
 smn:Entity rdfs:comment "Plain-language anchor for the thing a salmon dataset is about: a fish, group, habitat unit, stock, river, or similar feature."@en ;
   skos:closeMatch sosa:FeatureOfInterest, iadopt:Entity .
 
 smn:GeographicFeature skos:closeMatch sosa:FeatureOfInterest .
-
-sosa:FeatureOfInterest skos:closeMatch iadopt:Entity .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# --- END REQUIRED ANNOTATION BACKFILL ---

--- a/ontology/views/salmon-data-metamodel-event-observation.ttl
+++ b/ontology/views/salmon-data-metamodel-event-observation.ttl
@@ -7,13 +7,12 @@
 @prefix sosa:   <http://www.w3.org/ns/sosa/> .
 @prefix iadopt: <https://w3id.org/iadopt/ont/> .
 @prefix dwc:    <http://rs.tdwg.org/dwc/terms/> .
+@prefix iao:    <http://purl.obolibrary.org/obo/IAO_> .
 
 <https://w3id.org/smn/views/salmon-data-metamodel/event-observation> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view — event/observation slice"@en ;
-  rdfs:comment "Simple observation/event slice: when and where the work happened."@en .
-
-sosa:Observation rdfs:subClassOf prov:Activity .
-sosa:Sampling rdfs:subClassOf prov:Activity .
+  rdfs:comment "Simple observation/event slice: when and where the work happened. The SOSA-to-PROV class axioms formerly asserted here come, since 2026-08-13, from the imported W3C alignment (module alignment-upper); the SOSA-to-Darwin-Core bridges live in alignment-main."@en ;
+  rdfs:seeAlso <https://w3id.org/smn/modules/alignment-upper> .
 
 smn:Measurement skos:closeMatch sosa:Observation .
 smn:SamplingEvent skos:closeMatch sosa:Sampling .
@@ -25,49 +24,33 @@ smn:ReportingOrManagementStratum rdfs:comment "In salmon practice this is often 
 
 smnv:SalmonDataObservation a owl:Class ;
   rdfs:label "salmon data observation"@en ;
+  iao:0000115 "A metamodel observation activity that applies a variable to a feature of interest using a procedure and yields a result."@en ;
   rdfs:subClassOf sosa:Observation ,
     [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:someValuesFrom sosa:FeatureOfInterest ] ,
     [ a owl:Restriction ; owl:onProperty smnv:hasVariable ; owl:someValuesFrom iadopt:Variable ] ,
-    [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:someValuesFrom sosa:Result ] .
+    [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:someValuesFrom sosa:Result ] ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:SalmonDataSampling a owl:Class ;
   rdfs:label "salmon data sampling"@en ;
+  iao:0000115 "A metamodel sampling activity that applies a variable to a feature of interest and yields a sample."@en ;
   rdfs:subClassOf sosa:Sampling ,
     [ a owl:Restriction ; owl:onProperty sosa:hasFeatureOfInterest ; owl:someValuesFrom sosa:FeatureOfInterest ] ,
-    [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:someValuesFrom sosa:Sample ] .
+    [ a owl:Restriction ; owl:onProperty sosa:hasResult ; owl:someValuesFrom sosa:Sample ] ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:observationUsedFeature a owl:ObjectProperty ;
   rdfs:label "observation used feature"@en ;
-  rdfs:subPropertyOf sosa:hasFeatureOfInterest, prov:used ;
+  iao:0000115 "Relates an observation activity to the feature of interest it addresses."@en ;
+  rdfs:subPropertyOf sosa:hasFeatureOfInterest ;
   rdfs:domain sosa:Observation ;
-  rdfs:range sosa:FeatureOfInterest .
+  rdfs:range sosa:FeatureOfInterest ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:samplingMadeBySampler a owl:ObjectProperty ;
   rdfs:label "sampling made by sampler"@en ;
+  iao:0000115 "Relates a sampling activity to the agent or instrument that performed it."@en ;
   rdfs:subPropertyOf sosa:madeBySampler ;
   rdfs:domain sosa:Sampling ;
-  rdfs:range sosa:Sampler .
-
-sosa:Sampling skos:closeMatch dwc:Event .
-sosa:Observation skos:closeMatch dwc:Occurrence .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
-
-<https://w3id.org/smn/views/salmon-data-metamodel#SalmonDataObservation>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "A metamodel observation activity that applies a variable to a feature of interest using a procedure and yields a result."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#SalmonDataSampling>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "A metamodel sampling activity that applies a variable to a feature of interest and yields a sample."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#observationUsedFeature>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates an observation activity to the feature of interest it addresses."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#samplingMadeBySampler>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a sampling activity to the agent or instrument that performed it."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-# --- END REQUIRED ANNOTATION BACKFILL ---
+  rdfs:range sosa:Sampler ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .

--- a/ontology/views/salmon-data-metamodel-method-protocol.ttl
+++ b/ontology/views/salmon-data-metamodel-method-protocol.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sosa:   <http://www.w3.org/ns/sosa/> .
 @prefix dwc:    <http://rs.tdwg.org/dwc/terms/> .
+@prefix iao:    <http://purl.obolibrary.org/obo/IAO_> .
 
 <https://w3id.org/smn/views/salmon-data-metamodel/method-protocol> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view — method/protocol slice"@en ;
@@ -13,38 +14,27 @@ smn:MethodDocumentation rdfs:comment "Shared salmon anchor for the method or pro
 
 smnv:observationUsedProcedure a owl:ObjectProperty ;
   rdfs:label "observation used procedure"@en ;
+  iao:0000115 "Relates an observation activity to the procedure used to perform it."@en ;
   rdfs:subPropertyOf sosa:usedProcedure ;
   rdfs:domain sosa:Observation ;
-  rdfs:range sosa:Procedure .
+  rdfs:range sosa:Procedure ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:samplingUsedProcedure a owl:ObjectProperty ;
   rdfs:label "sampling used procedure"@en ;
+  iao:0000115 "Relates a sampling activity to the procedure used to perform it."@en ;
   rdfs:subPropertyOf sosa:usedProcedure ;
   rdfs:domain sosa:Sampling ;
-  rdfs:range sosa:Procedure .
+  rdfs:range sosa:Procedure ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:procedureDocumentedBy a owl:ObjectProperty ;
   rdfs:label "procedure documented by"@en ;
+  iao:0000115 "Relates a procedure to documentation that specifies or describes how it is applied."@en ;
   rdfs:comment "Links a procedure to the documentation that explains it."@en ;
   rdfs:domain sosa:Procedure ;
-  rdfs:range smn:MethodDocumentation .
+  rdfs:range smn:MethodDocumentation ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 sosa:ObservingProcedure rdfs:comment "Documentation-only bridge: in salmon data exchange this usually points to a referenced protocol description rather than an OWL-equivalent class."@en ;
   rdfs:seeAlso dwc:samplingProtocol .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
-
-<https://w3id.org/smn/views/salmon-data-metamodel#observationUsedProcedure>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates an observation activity to the procedure used to perform it."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#procedureDocumentedBy>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a procedure to documentation that specifies or describes how it is applied."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#samplingUsedProcedure>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a sampling activity to the procedure used to perform it."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-# --- END REQUIRED ANNOTATION BACKFILL ---

--- a/ontology/views/salmon-data-metamodel-property.ttl
+++ b/ontology/views/salmon-data-metamodel-property.ttl
@@ -4,21 +4,13 @@
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
 @prefix sosa:  <http://www.w3.org/ns/sosa/> .
 @prefix iadopt: <https://w3id.org/iadopt/ont/> .
-@prefix iao:   <http://purl.obolibrary.org/obo/IAO_> .
 
 <https://w3id.org/smn/views/salmon-data-metamodel/property> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view — property slice"@en ;
-  rdfs:comment "Property-focused slice: the aspect or characteristic of a salmon entity that an observation is trying to describe."@en .
-
-iadopt:Property rdfs:subClassOf iao:0000030 .
+  rdfs:comment "Property-focused slice: the aspect or characteristic of a salmon entity that an observation is trying to describe. The former foreign-subject axioms (iadopt:Property under IAO information content entity — rejected 2026-08-13, F5: I-ADOPT defines Property as a characteristic, not a description; and the iadopt/sosa closeMatch) were removed; the surviving bridge lives in alignment-main."@en .
 
 smn:Characteristic rdfs:comment "Plain-language anchor for the aspect being described, such as length, weight, abundance, escapement, or life stage."@en ;
   skos:closeMatch sosa:Property, iadopt:Property .
 
 smn:FishLength skos:closeMatch iadopt:Property .
 smn:FishWeight skos:closeMatch iadopt:Property .
-
-sosa:Property skos:closeMatch iadopt:Property .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# --- END REQUIRED ANNOTATION BACKFILL ---

--- a/ontology/views/salmon-data-metamodel-provenance.ttl
+++ b/ontology/views/salmon-data-metamodel-provenance.ttl
@@ -2,18 +2,11 @@
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix prov:  <http://www.w3.org/ns/prov#> .
-@prefix sosa:  <http://www.w3.org/ns/sosa/> .
 
 <https://w3id.org/smn/views/salmon-data-metamodel/provenance> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view — provenance slice"@en ;
-  rdfs:comment "Provenance slice: lightweight lineage links showing how salmon observations use inputs, generate outputs, and derive samples."@en .
+  rdfs:comment "Provenance slice: lightweight lineage links for salmon observations. The sosa-to-prov property subsumptions formerly re-asserted here (hasFeatureOfInterest under prov:used, hasResult under prov:generated, isSampleOf under prov:wasDerivedFrom) are exactly the W3C-published alignment's axioms, imported since 2026-08-13 via module alignment-upper rather than restated. Only smn-owned subjects remain below."@en ;
+  rdfs:seeAlso <https://w3id.org/smn/modules/alignment-upper> .
 
 smn:MethodDocumentation rdfs:subClassOf prov:Entity .
 smn:DataQualityAssessment rdfs:subClassOf prov:Entity .
-
-sosa:hasFeatureOfInterest rdfs:subPropertyOf prov:used .
-sosa:hasResult rdfs:subPropertyOf prov:generated .
-sosa:isSampleOf rdfs:subPropertyOf prov:wasDerivedFrom .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# --- END REQUIRED ANNOTATION BACKFILL ---

--- a/ontology/views/salmon-data-metamodel-result-datum.ttl
+++ b/ontology/views/salmon-data-metamodel-result-datum.ttl
@@ -5,42 +5,29 @@
 @prefix skos:   <http://www.w3.org/2004/02/skos/core#> .
 @prefix prov:   <http://www.w3.org/ns/prov#> .
 @prefix sosa:   <http://www.w3.org/ns/sosa/> .
-@prefix dwc:    <http://rs.tdwg.org/dwc/terms/> .
+@prefix iao:    <http://purl.obolibrary.org/obo/IAO_> .
 
 <https://w3id.org/smn/views/salmon-data-metamodel/result-datum> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view — result/datum slice"@en ;
-  rdfs:comment "Simple result slice: what comes out of an observation or sampling act."@en .
+  rdfs:comment "Simple result slice: what comes out of an observation or sampling act. The SOSA-to-PROV axioms formerly asserted here come, since 2026-08-13, from the imported W3C alignment (module alignment-upper; note sosa:Sample under prov:Entity is entailed there via sosa:FeatureOfInterest — the W3C file never states it directly, and neither does smn). The Sample-to-MaterialSample bridge lives in alignment-main."@en ;
+  rdfs:seeAlso <https://w3id.org/smn/modules/alignment-upper> .
 
-sosa:Sample rdfs:subClassOf prov:Entity .
-sosa:Result rdfs:subClassOf prov:Entity .
-
-smn:EscapementMeasurement skos:closeMatch sosa:Result .
+smn:EscapementEstimate skos:closeMatch sosa:Result .
 smn:ObservedRateOrAbundance skos:closeMatch sosa:Result .
 smn:TargetOrLimitRateOrAbundance skos:closeMatch sosa:Result .
 
 smnv:observationGeneratedResult a owl:ObjectProperty ;
   rdfs:label "observation generated result"@en ;
+  iao:0000115 "Relates an observation activity to the result datum it produces."@en ;
   rdfs:subPropertyOf sosa:hasResult, prov:generated ;
   rdfs:domain sosa:Observation ;
-  rdfs:range sosa:Result .
+  rdfs:range sosa:Result ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:samplingGeneratedSample a owl:ObjectProperty ;
   rdfs:label "sampling generated sample"@en ;
+  iao:0000115 "Relates a sampling activity to the sample it generates."@en ;
   rdfs:subPropertyOf sosa:hasResult, prov:generated ;
   rdfs:domain sosa:Sampling ;
-  rdfs:range sosa:Sample .
-
-sosa:Sample skos:closeMatch dwc:MaterialSample .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
-
-<https://w3id.org/smn/views/salmon-data-metamodel#observationGeneratedResult>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates an observation activity to the result datum it produces."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#samplingGeneratedSample>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a sampling activity to the sample it generates."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-# --- END REQUIRED ANNOTATION BACKFILL ---
+  rdfs:range sosa:Sample ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .

--- a/ontology/views/salmon-data-metamodel-variable.ttl
+++ b/ontology/views/salmon-data-metamodel-variable.ttl
@@ -9,10 +9,7 @@
 
 <https://w3id.org/smn/views/salmon-data-metamodel/variable> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view — variable slice"@en ;
-  rdfs:comment "Simple variable slice: the practical thing salmon teams often call a variable."@en .
-
-iadopt:Variable rdfs:subClassOf iao:0000030, sosa:Property .
-iadopt:Constraint rdfs:subClassOf iao:0000030 .
+  rdfs:comment "Simple variable slice: the practical thing salmon teams often call a variable. Since 2026-08-13 every smnv decomposition property is declared rdfs:subPropertyOf its native I-ADOPT counterpart (F3), so data described with the plain-language properties stays visible to I-ADOPT-aware consumers; the former foreign-subject axioms on iadopt terms were removed (F1/F5), and the iadopt:Variable bridge to SOSA lives in alignment-main as closeMatch to sosa:ObservableProperty."@en .
 
 smn:MeasurementContext skos:relatedMatch iadopt:Constraint .
 smn:CatchContext skos:relatedMatch iadopt:Constraint .
@@ -25,78 +22,61 @@ smn:ReferencePoint skos:closeMatch iadopt:Constraint .
 
 smnv:SalmonDataVariable a owl:Class ;
   rdfs:label "salmon data variable"@en ;
+  iao:0000115 "A metamodel variable representing an observed property of an entity with optional constraints and statistical modifiers."@en ;
   rdfs:comment "A simple helper class for the common salmon-data pattern where a variable bundles an entity, a property, and any important context."@en ;
   rdfs:subClassOf iadopt:Variable ,
     [ a owl:Restriction ; owl:onProperty smnv:variableRepresentsEntity ; owl:someValuesFrom iadopt:Entity ] ,
-    [ a owl:Restriction ; owl:onProperty smnv:variableRepresentsProperty ; owl:someValuesFrom iadopt:Property ] .
+    [ a owl:Restriction ; owl:onProperty smnv:variableRepresentsProperty ; owl:someValuesFrom iadopt:Property ] ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:variableRepresentsEntity a owl:ObjectProperty ;
   rdfs:label "variable represents entity"@en ;
-  rdfs:comment "Links a variable to the entity or feature it is about."@en ;
+  iao:0000115 "Relates a variable to the entity that is the object of interest for the variable."@en ;
+  rdfs:comment "Links a variable to the entity or feature it is about. Declared under iadopt:hasObjectOfInterest as the intended default of I-ADOPT's three entity roles (object of interest, context object, matrix); use the native iadopt properties directly when the finer role matters."@en ;
+  rdfs:subPropertyOf iadopt:hasObjectOfInterest ;
   rdfs:domain iadopt:Variable ;
-  rdfs:range iadopt:Entity .
+  rdfs:range iadopt:Entity ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:variableRepresentsProperty a owl:ObjectProperty ;
   rdfs:label "variable represents property"@en ;
+  iao:0000115 "Relates a variable to the property or characteristic it represents."@en ;
   rdfs:comment "Links a variable to the property or characteristic being described."@en ;
+  rdfs:subPropertyOf iadopt:hasProperty ;
   rdfs:domain iadopt:Variable ;
-  rdfs:range iadopt:Property .
+  rdfs:range iadopt:Property ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:variableUsesConstraint a owl:ObjectProperty ;
   rdfs:label "variable uses constraint"@en ;
+  iao:0000115 "Relates a variable to a constraint that narrows its interpretation or scope."@en ;
   rdfs:comment "Adds context such as brood year, location, life stage, or benchmark framing when it changes the meaning of the variable."@en ;
+  rdfs:subPropertyOf iadopt:hasConstraint ;
   rdfs:domain iadopt:Variable ;
-  rdfs:range iadopt:Constraint .
+  rdfs:range iadopt:Constraint ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:variableUsesStatisticalModifier a owl:ObjectProperty ;
   rdfs:label "variable uses statistical modifier"@en ;
-  rdfs:comment "Captures choices such as average, count, proportion, or confidence framing."@en ;
+  iao:0000115 "Relates a variable to a statistical modifier that qualifies how the variable is summarized or expressed."@en ;
+  rdfs:comment "Captures choices such as average, count, proportion, or peak. Range tightened from owl:Thing to iadopt:StatisticalModifier on 2026-08-13 (F8): I-ADOPT 1.1.0 provides the class natively."@en ;
+  rdfs:subPropertyOf iadopt:hasStatisticalModifier ;
   rdfs:domain iadopt:Variable ;
-  rdfs:range owl:Thing .
+  rdfs:range iadopt:StatisticalModifier ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:hasVariable a owl:ObjectProperty ;
   rdfs:label "has variable"@en ;
+  iao:0000115 "Relates an observation or sampling activity to the variable it applies."@en ;
   rdfs:comment "Links an observation to the variable framing used in the workflow."@en ;
   rdfs:domain sosa:Observation ;
-  rdfs:range iadopt:Variable .
+  rdfs:range iadopt:Variable ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .
 
 smnv:constraintConstrains a owl:ObjectProperty ;
   rdfs:label "constraint constrains"@en ;
+  iao:0000115 "Relates a variable constraint to the variable it qualifies."@en ;
   rdfs:subPropertyOf iadopt:constrains ;
   rdfs:domain iadopt:Constraint ;
-  rdfs:range owl:Thing .
-
-iadopt:Variable skos:closeMatch sosa:Property .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
-
-<https://w3id.org/smn/views/salmon-data-metamodel#SalmonDataVariable>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "A metamodel variable representing an observed property of an entity with optional constraints and statistical modifiers."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#constraintConstrains>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a variable constraint to the variable it qualifies."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#hasVariable>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates an observation or sampling activity to the variable it applies."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#variableRepresentsEntity>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a variable to the entity that is the object of interest for the variable."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#variableRepresentsProperty>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a variable to the property or characteristic it represents."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#variableUsesConstraint>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a variable to a constraint that narrows its interpretation or scope."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-<https://w3id.org/smn/views/salmon-data-metamodel#variableUsesStatisticalModifier>
-  <http://purl.obolibrary.org/obo/IAO_0000115> "Relates a variable to a statistical modifier that qualifies how the variable is summarized or expressed."@en ;
-  <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/views/salmon-data-metamodel> .
-
-# --- END REQUIRED ANNOTATION BACKFILL ---
+  rdfs:range owl:Thing ;
+  rdfs:isDefinedBy <https://w3id.org/smn/views/salmon-data-metamodel> .

--- a/ontology/views/salmon-data-metamodel.ttl
+++ b/ontology/views/salmon-data-metamodel.ttl
@@ -3,15 +3,12 @@
 
 <https://w3id.org/smn/views/salmon-data-metamodel> a owl:Ontology ;
   rdfs:label "Salmon data metamodel view"@en ;
-  rdfs:comment "Optional, non-normative mental model for the shared salmon ontology. It gives a simple reading of how entity, property, variable, context, method, observation, result, and provenance fit together. This view is intentionally not imported by the shared-core 01-07 build."@en ;
+  rdfs:comment "Optional, non-normative mental model for the shared salmon ontology. It gives a simple reading of how entity, property, variable, context, method, observation, result, and provenance fit together. This view is intentionally not imported by the shared-core 01-07 build. Since 2026-08-13 the views are axiom-light: they state nothing about foreign-namespace terms — the load-bearing upper alignments live in the normative modules alignment-upper (imported W3C SOSA-PROV alignment) and alignment-main (reviewed Tier-3 bridges). Imports use the sub-views' ontology IRIs, resolved locally via catalog-v001.xml."@en ;
   owl:imports
-    <salmon-data-metamodel-entity.ttl> ,
-    <salmon-data-metamodel-property.ttl> ,
-    <salmon-data-metamodel-variable.ttl> ,
-    <salmon-data-metamodel-method-protocol.ttl> ,
-    <salmon-data-metamodel-event-observation.ttl> ,
-    <salmon-data-metamodel-result-datum.ttl> ,
-    <salmon-data-metamodel-provenance.ttl> .
-
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# --- END REQUIRED ANNOTATION BACKFILL ---
+    <https://w3id.org/smn/views/salmon-data-metamodel/entity> ,
+    <https://w3id.org/smn/views/salmon-data-metamodel/property> ,
+    <https://w3id.org/smn/views/salmon-data-metamodel/variable> ,
+    <https://w3id.org/smn/views/salmon-data-metamodel/method-protocol> ,
+    <https://w3id.org/smn/views/salmon-data-metamodel/event-observation> ,
+    <https://w3id.org/smn/views/salmon-data-metamodel/result-datum> ,
+    <https://w3id.org/smn/views/salmon-data-metamodel/provenance> .

--- a/salmon-domain-ontology.ttl
+++ b/salmon-domain-ontology.ttl
@@ -4,25 +4,50 @@
 # DO NOT edit manually. Rebuild with `make compose-flat-ttl`.
 
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix ns1: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+sosa:Actuator rdfs:subClassOf prov:Agent,
+        prov:Entity .
+
 sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon data exchange this usually points to a Darwin Core protocol value or a DwC-DP Protocol record, not to an OWL-equivalent class."@en ;
     rdfs:seeAlso <http://rs.tdwg.org/dwc/terms/protocol>,
         <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
 
-<https://w3id.org/iadopt/ont/Property> owl:equivalentClass sosa:Property .
+sosa:Platform rdfs:subClassOf prov:Entity .
+
+sosa:Sampler rdfs:subClassOf prov:Agent,
+        prov:Entity .
+
+sosa:Sensor rdfs:subClassOf prov:Agent,
+        prov:Entity .
+
+sosa:isResultOf rdfs:subPropertyOf prov:wasGeneratedBy .
+
+sosa:isSampleOf rdfs:subPropertyOf prov:wasDerivedFrom .
+
+sosa:madeByActuator rdfs:subPropertyOf prov:wasAssociatedWith .
+
+sosa:madeBySampler rdfs:subPropertyOf prov:wasAssociatedWith .
+
+sosa:madeBySensor rdfs:subPropertyOf prov:wasAssociatedWith .
+
+<https://w3id.org/iadopt/ont/Property> skos:closeMatch sosa:Property .
 
 <https://w3id.org/iadopt/ont/StatisticalModifier> a owl:Class .
 
-<https://w3id.org/iadopt/ont/Variable> a owl:Class .
+<https://w3id.org/iadopt/ont/Variable> a owl:Class ;
+    skos:closeMatch sosa:ObservableProperty .
 
 <https://w3id.org/smn/AgeAtMaturityBasis> a skos:Concept ;
     ns1:IAO_0000119 "Adapted from GC DFO Salmon Ontology term gcdfo:AgeAtMaturityBasis."@en ;
@@ -166,11 +191,12 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf ns1:BFO_0000015 .
 
-<https://w3id.org/smn/EscapementMeasurement> a owl:Class ;
-    rdfs:label "Escapement measurement"@en ;
+<https://w3id.org/smn/EscapementEstimate> a owl:Class ;
+    rdfs:label "Escapement estimate"@en ;
     ns1:IAO_0000115 "A measurement or estimate of escapement tied to a stock and a survey event."@en ;
     ns1:IAO_0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementMeasurement."@en ;
     dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> ;
+    rdfs:comment "A datum (IAO measurement datum), not an activity: the corresponding survey activity is smn:EscapementSurveyEvent. Renamed from smn:EscapementMeasurement on 2026-08-13 (alignment pass, finding F6) because every other *Measurement class in this module is a subclass of the activity smn:Measurement, and this one is not — the name was the defect, inherited verbatim from gcdfo:EscapementMeasurement, whose hyponym family should be coordinated in the boundary pass."@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf ns1:IAO_0000109 ;
     skos:closeMatch sosa:Result .
@@ -536,7 +562,13 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
 
 <https://w3id.org/smn/modules/alignment-main> a owl:Ontology ;
     rdfs:label "Salmon Domain Ontology Alignment Module (main-candidate)"@en ;
-    rdfs:comment "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research)."@en .
+    rdfs:comment "Conservative upper-level alignment bridges adapted from DFO Salmon Ontology alignment branch (feat/alignment-modules-main-research). This is the only module in the default build permitted to carry mapping statements whose subjects are foreign-namespace terms (CONVENTIONS section 5b): each such statement is a reviewed editorial commitment, held at Tier 3 (advisory) unless an upstream body publishes the stronger form — in which case smn imports the upstream alignment (see alignment-upper) instead of restating it."@en .
+
+<https://w3id.org/smn/modules/alignment-upper> a owl:Ontology ;
+    rdfs:label "Salmon Domain Ontology upper alignment (imported W3C alignments)"@en ;
+    dcterms:source sosa:prov ;
+    rdfs:comment "Normative-core upper alignment. Imports the W3C-published SOSA-to-PROV-O alignment instead of re-asserting its axioms on foreign-namespace terms — the convention this module exists to enforce: smn never states axioms whose subjects it does not own outside a reviewed alignment module, and where an upstream body already publishes the alignment, smn imports it. The SOSA-PROV alignment is non-normative in the SSN Recommendation (2017, section 6.5); smn adopts it as the provenance backbone for the deterministic-reasoning consumption target. Offline and CI loading resolves the import to the vendored snapshot ontology/imports/sosa-prov.ttl via catalog-v001.xml; the snapshot is a byte copy of the W3C file and must not be hand-edited."@en ;
+    rdfs:seeAlso <https://www.w3.org/TR/vocab-ssn/#PROV> .
 
 <https://w3id.org/smn/observedTaxonFamily> a owl:ObjectProperty ;
     rdfs:label "observed taxon family"@en ;
@@ -578,7 +610,44 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/FishLength> .
 
-<https://w3id.org/iadopt/ont/Entity> owl:equivalentClass sosa:FeatureOfInterest .
+sosa:Actuation rdfs:subClassOf prov:Activity .
+
+sosa:ObservableProperty rdfs:subClassOf prov:Entity .
+
+sosa:Result rdfs:subClassOf prov:Entity .
+
+sosa:Sample rdfs:subClassOf prov:Entity ;
+    skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
+        <http://rs.tdwg.org/dwc/terms/MaterialSample> .
+
+sosa:hasResult rdfs:subPropertyOf prov:generated .
+
+sosa:prov a owl:Ontology ;
+    rdfs:label "Alignment of SOSA with PROV-O"@en ;
+    dcterms:created "2016-12-14"^^xsd:date ;
+    dcterms:creator [ a foaf:Agent ;
+            foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ],
+        "Simon J D Cox" ;
+    dcterms:license <http://www.opengeospatial.org/ogc/Software>,
+        <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
+    dcterms:modified "2017-04-13"^^xsd:date ;
+    dcterms:rights "Copyright 2017 W3C/OGC." ;
+    rdfs:comment "Alignment of the the W3C/OGC SOSA Ontology with the W3C PROV-O Ontology"@en .
+
+<http://www.w3.org/ns/sosa/prov/eventAssociation> a owl:ObjectProperty ;
+    rdfs:domain [ a owl:Class ;
+            owl:unionOf ( sosa:Observation sosa:Actuation sosa:Sampling ) ] ;
+    rdfs:subPropertyOf prov:qualifiedAssociation .
+
+<http://www.w3.org/ns/sosa/prov/hadProcedure> a owl:ObjectProperty ;
+    rdfs:range sosa:Procedure ;
+    rdfs:subPropertyOf prov:hadPlan .
+
+sosa:resultTime rdfs:subPropertyOf prov:endedAtTime .
+
+sosa:usedProcedure owl:propertyChainAxiom ( <http://www.w3.org/ns/sosa/prov/eventAssociation> <http://www.w3.org/ns/sosa/prov/hadProcedure> ) .
+
+<https://w3id.org/iadopt/ont/Entity> skos:closeMatch sosa:FeatureOfInterest .
 
 <https://w3id.org/smn/AggregatedMeasurement> a owl:Class ;
     rdfs:label "Aggregated measurement"@en ;
@@ -742,12 +811,7 @@ ns1:NCBITaxon_8018 rdfs:subClassOf ns1:NCBITaxon_8015 .
 
 geo:Feature rdfs:subClassOf sosa:FeatureOfInterest .
 
-sosa:Procedure skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
-
-sosa:Sample rdfs:comment "Crosswalk used MaterialEntity; aligned here to Darwin Core MaterialSample for concrete publication workflows."@en ;
-    owl:equivalentClass <http://rs.tdwg.org/dwc/terms/MaterialSample> ;
-    skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity> ;
-    sosa:isResultOf sosa:Sampling .
+sosa:hasFeatureOfInterest rdfs:subPropertyOf prov:used .
 
 <https://w3id.org/smn/Abundance> a owl:Class ;
     rdfs:label "Abundance"@en ;
@@ -809,8 +873,8 @@ sosa:Sample rdfs:comment "Crosswalk used MaterialEntity; aligned here to Darwin 
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/Entity> .
 
-sosa:Observation owl:equivalentClass <http://rs.tdwg.org/dwc/terms/Occurrence> ;
-    skos:closeMatch <http://rs.tdwg.org/dwc/terms/Occurrence> .
+sosa:Procedure rdfs:subClassOf prov:Plan ;
+    skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
 
 <https://w3id.org/smn/AgeNotation> a skos:Concept ;
     ns1:IAO_0000119 "Migrated from GC DFO Salmon Ontology term gcdfo:AgeNotation."@en ;
@@ -901,8 +965,11 @@ sosa:Observation owl:equivalentClass <http://rs.tdwg.org/dwc/terms/Occurrence> ;
     skos:hasTopConcept <https://w3id.org/smn/SalmonOrigin> ;
     skos:prefLabel "Salmon origin scheme"@en .
 
-sosa:Sampling owl:equivalentClass <http://rs.tdwg.org/dwc/terms/Event> ;
-    skos:closeMatch <http://rs.tdwg.org/dwc/terms/Event> .
+sosa:Observation rdfs:subClassOf prov:Activity ;
+    skos:closeMatch <http://rs.tdwg.org/dwc/terms/Occurrence> .
+
+sosa:Sampling rdfs:subClassOf prov:Activity ;
+    skos:broadMatch <http://rs.tdwg.org/dwc/terms/Event> .
 
 <https://w3id.org/smn/AgeBasis> a skos:Concept ;
     ns1:IAO_0000119 "Migrated from GC DFO Salmon Ontology term gcdfo:AgeBasis."@en ;
@@ -1033,7 +1100,7 @@ sosa:Sampling owl:equivalentClass <http://rs.tdwg.org/dwc/terms/Event> ;
 
 <https://w3id.org/iadopt/ont/Constraint> a owl:Class .
 
-sosa:FeatureOfInterest sosa:hasSample sosa:Sample .
+sosa:FeatureOfInterest rdfs:subClassOf prov:Entity .
 
 <https://w3id.org/smn/AgeClassValue> a skos:Concept ;
     ns1:IAO_0000119 "Adapted and relabeled from GC DFO Salmon Ontology term gcdfo:AgeClassValue."@en ;

--- a/salmon-domain-ontology.ttl
+++ b/salmon-domain-ontology.ttl
@@ -4,43 +4,19 @@
 # DO NOT edit manually. Rebuild with `make compose-flat-ttl`.
 
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix geo: <http://www.opengis.net/ont/geosparql#> .
 @prefix ns1: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix qb: <http://purl.org/linked-data/cube#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sosa: <http://www.w3.org/ns/sosa/> .
 @prefix time: <http://www.w3.org/2006/time#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-sosa:Actuator rdfs:subClassOf prov:Agent,
-        prov:Entity .
-
 sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon data exchange this usually points to a Darwin Core protocol value or a DwC-DP Protocol record, not to an OWL-equivalent class."@en ;
     rdfs:seeAlso <http://rs.tdwg.org/dwc/terms/protocol>,
         <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
-
-sosa:Platform rdfs:subClassOf prov:Entity .
-
-sosa:Sampler rdfs:subClassOf prov:Agent,
-        prov:Entity .
-
-sosa:Sensor rdfs:subClassOf prov:Agent,
-        prov:Entity .
-
-sosa:isResultOf rdfs:subPropertyOf prov:wasGeneratedBy .
-
-sosa:isSampleOf rdfs:subPropertyOf prov:wasDerivedFrom .
-
-sosa:madeByActuator rdfs:subPropertyOf prov:wasAssociatedWith .
-
-sosa:madeBySampler rdfs:subPropertyOf prov:wasAssociatedWith .
-
-sosa:madeBySensor rdfs:subPropertyOf prov:wasAssociatedWith .
 
 <https://w3id.org/iadopt/ont/Property> skos:closeMatch sosa:Property .
 
@@ -610,42 +586,8 @@ sosa:madeBySensor rdfs:subPropertyOf prov:wasAssociatedWith .
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/FishLength> .
 
-sosa:Actuation rdfs:subClassOf prov:Activity .
-
-sosa:ObservableProperty rdfs:subClassOf prov:Entity .
-
-sosa:Result rdfs:subClassOf prov:Entity .
-
-sosa:Sample rdfs:subClassOf prov:Entity ;
-    skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
+sosa:Sample skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
         <http://rs.tdwg.org/dwc/terms/MaterialSample> .
-
-sosa:hasResult rdfs:subPropertyOf prov:generated .
-
-sosa:prov a owl:Ontology ;
-    rdfs:label "Alignment of SOSA with PROV-O"@en ;
-    dcterms:created "2016-12-14"^^xsd:date ;
-    dcterms:creator [ a foaf:Agent ;
-            foaf:name "W3C/OGC Spatial Data on the Web Working Group"@en ],
-        "Simon J D Cox" ;
-    dcterms:license <http://www.opengeospatial.org/ogc/Software>,
-        <http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
-    dcterms:modified "2017-04-13"^^xsd:date ;
-    dcterms:rights "Copyright 2017 W3C/OGC." ;
-    rdfs:comment "Alignment of the the W3C/OGC SOSA Ontology with the W3C PROV-O Ontology"@en .
-
-<http://www.w3.org/ns/sosa/prov/eventAssociation> a owl:ObjectProperty ;
-    rdfs:domain [ a owl:Class ;
-            owl:unionOf ( sosa:Observation sosa:Actuation sosa:Sampling ) ] ;
-    rdfs:subPropertyOf prov:qualifiedAssociation .
-
-<http://www.w3.org/ns/sosa/prov/hadProcedure> a owl:ObjectProperty ;
-    rdfs:range sosa:Procedure ;
-    rdfs:subPropertyOf prov:hadPlan .
-
-sosa:resultTime rdfs:subPropertyOf prov:endedAtTime .
-
-sosa:usedProcedure owl:propertyChainAxiom ( <http://www.w3.org/ns/sosa/prov/eventAssociation> <http://www.w3.org/ns/sosa/prov/hadProcedure> ) .
 
 <https://w3id.org/iadopt/ont/Entity> skos:closeMatch sosa:FeatureOfInterest .
 
@@ -811,7 +753,7 @@ ns1:NCBITaxon_8018 rdfs:subClassOf ns1:NCBITaxon_8015 .
 
 geo:Feature rdfs:subClassOf sosa:FeatureOfInterest .
 
-sosa:hasFeatureOfInterest rdfs:subPropertyOf prov:used .
+sosa:Procedure skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
 
 <https://w3id.org/smn/Abundance> a owl:Class ;
     rdfs:label "Abundance"@en ;
@@ -873,8 +815,9 @@ sosa:hasFeatureOfInterest rdfs:subPropertyOf prov:used .
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/Entity> .
 
-sosa:Procedure rdfs:subClassOf prov:Plan ;
-    skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
+sosa:Observation skos:closeMatch <http://rs.tdwg.org/dwc/terms/Occurrence> .
+
+sosa:Sampling skos:broadMatch <http://rs.tdwg.org/dwc/terms/Event> .
 
 <https://w3id.org/smn/AgeNotation> a skos:Concept ;
     ns1:IAO_0000119 "Migrated from GC DFO Salmon Ontology term gcdfo:AgeNotation."@en ;
@@ -964,12 +907,6 @@ sosa:Procedure rdfs:subClassOf prov:Plan ;
     skos:definition "Controlled vocabulary for describing the origin of individual salmon (e.g., natural-origin, hatchery-origin, mixed-origin)."@en ;
     skos:hasTopConcept <https://w3id.org/smn/SalmonOrigin> ;
     skos:prefLabel "Salmon origin scheme"@en .
-
-sosa:Observation rdfs:subClassOf prov:Activity ;
-    skos:closeMatch <http://rs.tdwg.org/dwc/terms/Occurrence> .
-
-sosa:Sampling rdfs:subClassOf prov:Activity ;
-    skos:broadMatch <http://rs.tdwg.org/dwc/terms/Event> .
 
 <https://w3id.org/smn/AgeBasis> a skos:Concept ;
     ns1:IAO_0000119 "Migrated from GC DFO Salmon Ontology term gcdfo:AgeBasis."@en ;
@@ -1099,8 +1036,6 @@ sosa:Sampling rdfs:subClassOf prov:Activity ;
     rdfs:subClassOf sosa:Property .
 
 <https://w3id.org/iadopt/ont/Constraint> a owl:Class .
-
-sosa:FeatureOfInterest rdfs:subClassOf prov:Entity .
 
 <https://w3id.org/smn/AgeClassValue> a skos:Concept ;
     ns1:IAO_0000119 "Adapted and relabeled from GC DFO Salmon Ontology term gcdfo:AgeClassValue."@en ;

--- a/scripts/build_flat_smn_ttl.py
+++ b/scripts/build_flat_smn_ttl.py
@@ -23,9 +23,18 @@ FLAT_DEFAULT = Path("salmon-domain-ontology.ttl")
 
 
 def discover_local_ontology_index() -> Dict[str, Path]:
-    """Build mapping of ontology IRI -> local file path for local module imports."""
+    """Build mapping of ontology IRI -> local file path for local module imports.
+
+    ontology/imports/ is deliberately excluded: it holds vendored snapshots of
+    upstream ontologies (the W3C SOSA-PROV alignment and its transitive
+    prov-o/sosa imports) that exist for offline catalog resolution only. The
+    flattened one-file artifact stays smn-authored content: inlining upstream
+    ontologies would triple its size and change its licensing story.
+    """
     index: Dict[str, Path] = {}
     for path in sorted(ONTOLOGY_ROOT.rglob("*.ttl")):
+        if "imports" in path.parts:
+            continue
         graph = Graph()
         graph.parse(path, format="turtle")
         ontology_iri = graph.value(predicate=RDF.type, object=OWL.Ontology)


### PR DESCRIPTION
Semantics half of alignment-pass **step 1** (metasalmon roadmap S9). Fixes verified findings F1–F7 and F8's property side; full rationale in `knowledge/data/owl-skos-conventions-state.md` and the metasalmon execplan.

**Design centerpiece:** `http://www.w3.org/ns/sosa/prov` dereferences to the actual W3C alignment Turtle, so the new `alignment-upper` module **imports** it — smn re-asserts nothing on foreign terms (a vendored byte-copy + `catalog-v001.xml` handles offline loading). Notably the W3C file never states `sosa:Sample ⊑ prov:Entity` (it is entailed) — the old views over-asserted even relative to W3C.

- Module 06's five `owl:equivalentClass` axioms → reviewed Tier-3 bridges in `alignment-main` (none is published upstream; Observation≡Occurrence / Sampling≡Event are wrong under any DwC vintage; `iadopt:Variable` now maps to `sosa:ObservableProperty`)
- Views: axiom-light teaching layer; `smnv:` properties bridged `rdfs:subPropertyOf` native `iop:` (I-ADOPT 1.1.0), `statisticalModifier` range → `iadopt:StatisticalModifier`; absolute-IRI imports
- `smn:EscapementMeasurement` → `smn:EscapementEstimate` (F6; gcdfo hyponym family coordinated in step 3)
- Module 02 class-level property assertions removed; CONVENTIONS gains §5b (one-strongest-mapping, foreign-subject placement, import-don't-restate, reasoner-clean invariant) and the instance-typing rule step 2 uses

**Verification:** all TTLs parse; `make test` green; flat TTL regenerated; rdflib checks: 0 foreign-subject violations, 0 tier-mixed pairs in the default spine. The ELK/robot CI gate + Makefile hygiene (verify-mutates-source, 08/09 drift gap) is the follow-up tooling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)