### PR TITLE
S9 steps 2+5: methods as SKOS concepts; statistical modifier scheme

### DIFF
--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -129,9 +129,6 @@ This ontology has the following classes and properties.</span>
       <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a>
    </li>
    <li>
-      <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a>
-   </li>
-   <li>
       <a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a>
    </li>
    <li>
@@ -152,14 +149,7 @@ This ontology has the following classes and properties.</span>
       </a>
    </li>
    <li>
-      <a href="#/FishForkLengthMeasurementMethod"
-         title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a>
-   </li>
-   <li>
       <a href="#/FishLength" title="https://w3id.org/smn/FishLength">Fish length</a>
-   </li>
-   <li>
-      <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a>
    </li>
    <li>
       <a href="#/FishLengthMeasurementType" title="https://w3id.org/smn/FishLengthMeasurementType">Fish length measurement type</a>
@@ -174,18 +164,7 @@ This ontology has the following classes and properties.</span>
       <a href="#/forkLength" title="https://w3id.org/smn/forkLength">Fork length</a>
    </li>
    <li>
-      <a href="#/ForkLengthMeasurementFieldMethod"
-         title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a>
-   </li>
-   <li>
-      <a href="#/ForkLengthMeasurementLabMethod"
-         title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a>
-   </li>
-   <li>
       <a href="#/ForkLengthMeasurement" title="https://w3id.org/smn/ForkLengthMeasurement">Fork-length measurement</a>
-   </li>
-   <li>
-      <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a>
    </li>
    <li>
       <a href="#/fusiform" title="https://w3id.org/smn/fusiform">Fusiform</a>
@@ -221,8 +200,7 @@ This ontology has the following classes and properties.</span>
       <a href="#/ModelMeasurement" title="https://w3id.org/smn/ModelMeasurement">Model measurement</a>
    </li>
    <li>
-      <a href="#/MorphologicalCharacteristic"
-         title="https://w3id.org/smn/MorphologicalCharacteristic">Morphological characteristic</a>
+      <a href="#/MorphologicalCharacteristic" title="https://w3id.org/smn/MorphologicalCharacteristic">Morphological characteristic</a>
    </li>
    <li>
       <a href="#http://purl.obolibrary.org/obo/NCBITaxon_8018" title="http://purl.obolibrary.org/obo/NCBITaxon_8018">
@@ -459,7 +437,33 @@ This ontology has the following classes and properties.</span>
       <a href="#/CatchYearBasis" title="https://w3id.org/smn/CatchYearBasis">Catch-year basis</a>
    </li>
    <li>
+      <a href="#/CountStatisticalModifier" title="https://w3id.org/smn/CountStatisticalModifier">Count</a>
+   </li>
+   <li>
+      <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a>
+   </li>
+   <li>
       <a href="#/EuropeanAgeNotation" title="https://w3id.org/smn/EuropeanAgeNotation">European age notation</a>
+   </li>
+   <li>
+      <a href="#/FishForkLengthMeasurementMethod"
+         title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a>
+   </li>
+   <li>
+      <a href="#/FishLengthMeasurementMethod"
+         title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a>
+   </li>
+   <li>
+      <a href="#/ForkLengthMeasurementFieldMethod"
+         title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a>
+   </li>
+   <li>
+      <a href="#/ForkLengthMeasurementLabMethod"
+         title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a>
+   </li>
+   <li>
+      <a href="#/ForkLengthMeasurementMethod"
+         title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a>
    </li>
    <li>
       <a href="#/FreshwaterAgeDimension" title="https://w3id.org/smn/FreshwaterAgeDimension">Freshwater-age dimension</a>
@@ -483,10 +487,25 @@ This ontology has the following classes and properties.</span>
       <a href="#/MainstemPhase" title="https://w3id.org/smn/MainstemPhase">Mainstem phase</a>
    </li>
    <li>
+      <a href="#/MaximumStatisticalModifier" title="https://w3id.org/smn/MaximumStatisticalModifier">Maximum</a>
+   </li>
+   <li>
+      <a href="#/MeanStatisticalModifier" title="https://w3id.org/smn/MeanStatisticalModifier">Mean</a>
+   </li>
+   <li>
       <a href="#/MeasurementContext" title="https://w3id.org/smn/MeasurementContext">Measurement context</a>
    </li>
    <li>
       <a href="#/MeasurementContextScheme" title="https://w3id.org/smn/MeasurementContextScheme">Measurement context scheme</a>
+   </li>
+   <li>
+      <a href="#/MedianStatisticalModifier" title="https://w3id.org/smn/MedianStatisticalModifier">Median</a>
+   </li>
+   <li>
+      <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a>
+   </li>
+   <li>
+      <a href="#/MinimumStatisticalModifier" title="https://w3id.org/smn/MinimumStatisticalModifier">Minimum</a>
    </li>
    <li>
       <a href="#/NaturalOrigin" title="https://w3id.org/smn/NaturalOrigin">Natural-origin</a>
@@ -496,6 +515,9 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#/OceanAgeDimension" title="https://w3id.org/smn/OceanAgeDimension">Ocean-age dimension</a>
+   </li>
+   <li>
+      <a href="#/PeakStatisticalModifier" title="https://w3id.org/smn/PeakStatisticalModifier">Peak</a>
    </li>
    <li>
       <a href="#/returnYear" title="https://w3id.org/smn/returnYear">
@@ -518,10 +540,16 @@ This ontology has the following classes and properties.</span>
       <a href="#/SpawnerStageContext" title="https://w3id.org/smn/SpawnerStageContext">Spawner stage context</a>
    </li>
    <li>
+      <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a>
+   </li>
+   <li>
       <a href="#/SurvivalOrMortalityContext" title="https://w3id.org/smn/SurvivalOrMortalityContext">Survival or mortality context</a>
    </li>
    <li>
       <a href="#/TerminalPhase" title="https://w3id.org/smn/TerminalPhase">Terminal phase</a>
+   </li>
+   <li>
+      <a href="#/TotalStatisticalModifier" title="https://w3id.org/smn/TotalStatisticalModifier">Total</a>
    </li>
    <li>
       <a href="#/TotalAgeDimension" title="https://w3id.org/smn/TotalAgeDimension">Total-age dimension</a>
@@ -558,24 +586,18 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/Deme" title="https://w3id.org/smn/Deme">Deme</a></li>
   <li><a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity"> <span>Entity</span> </a></li>
   <li><a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a></li>
-  <li><a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a></li>
   <li><a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a></li>
   <li><a href="#/EscapementEstimate" title="https://w3id.org/smn/EscapementEstimate">Escapement estimate</a></li>
   <li><a href="#/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement survey event</a></li>
   <li><a href="#/EventType" title="https://w3id.org/smn/EventType">Event type</a></li>
   <li><a href="#/ExploitationRate" title="https://w3id.org/smn/ExploitationRate">Exploitation rate</a></li>
   <li><a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature"> <span>Feature</span> </a></li>
-  <li><a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a></li>
   <li><a href="#/FishLength" title="https://w3id.org/smn/FishLength">Fish length</a></li>
-  <li><a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a></li>
   <li><a href="#/FishLengthMeasurementType" title="https://w3id.org/smn/FishLengthMeasurementType">Fish length measurement type</a></li>
   <li><a href="#/FishWeight" title="https://w3id.org/smn/FishWeight">Fish weight</a></li>
   <li><a href="#/FishingType" title="https://w3id.org/smn/FishingType">Fishing type</a></li>
   <li><a href="#/forkLength" title="https://w3id.org/smn/forkLength">Fork length</a></li>
-  <li><a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a></li>
-  <li><a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a></li>
   <li><a href="#/ForkLengthMeasurement" title="https://w3id.org/smn/ForkLengthMeasurement">Fork-length measurement</a></li>
-  <li><a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a></li>
   <li><a href="#/fusiform" title="https://w3id.org/smn/fusiform">Fusiform</a></li>
   <li><a href="#/GeographicFeature" title="https://w3id.org/smn/GeographicFeature">Geographic feature</a></li>
   <li><a href="#/HabitatUnit" title="https://w3id.org/smn/HabitatUnit">Habitat unit</a></li>
@@ -657,6 +679,9 @@ This section provides details for each class and property defined by Salmon Doma
  <div class="entity" id="/AggregatedMeasurement">
   <h3>Aggregated measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/AggregatedMeasurement</p>
+  <div class="comment">
+   <span class="markdown">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod).</span>
+  </div>
   <dl class="definedBy">
    <dt>
     Is defined by
@@ -893,46 +918,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/EnumerationMethod">
-  <h3>Enumeration method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/EnumerationMethod</p>
-  <div class="comment">
-   <span class="markdown">A method used to enumerate or count salmon in the field</span>
-  </div>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="definedBy">
-   <dt>
-    Source
-   </dt>
-   <dd>
-    GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod.
-   </dd>
-   <dd>
-    <a href="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl">https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    is in range of
-   </dt>
-   <dd>
-    <a href="#/basedOn" title="https://w3id.org/smn/basedOn">based on</a> <sup class="type-op" title="object property">op</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/Escapement">
   <h3>Escapement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Escapement</p>
@@ -1125,32 +1110,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/FishForkLengthMeasurementMethod">
-  <h3>Fish fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/FishForkLengthMeasurementMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/FishLength">
   <h3>Fish length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLength</p>
@@ -1177,35 +1136,12 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/FishLengthMeasurementMethod">
-  <h3>Fish length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/FishLengthMeasurementType">
   <h3>Fish length measurement type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementType</p>
+  <div class="comment">
+   <span class="markdown">The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class.</span>
+  </div>
   <dl class="definedBy">
    <dt>
     Is defined by
@@ -1295,46 +1231,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/ForkLengthMeasurementFieldMethod">
-  <h3>Fork-length field method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementFieldMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="/ForkLengthMeasurementLabMethod">
-  <h3>Fork-length lab method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementLabMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/ForkLengthMeasurement">
   <h3>Fork-length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurement</p>
@@ -1352,32 +1248,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dt>
    <dd>
     <a href="#/FishLengthMeasurementType" title="https://w3id.org/smn/FishLengthMeasurementType">Fish length measurement type</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="/ForkLengthMeasurementMethod">
-  <h3>Fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a> <sup class="type-c" title="class">c</sup>, <a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -1898,10 +1768,16 @@ This section provides details for each class and property defined by Salmon Doma
   <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/Procedure</p>
   <dl class="description">
    <dt>
-    has sub-classes
+    is in range of
    </dt>
    <dd>
-    <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>, <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
+    <a href="#/basedOn" title="https://w3id.org/smn/basedOn">based on</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    has members
+   </dt>
+   <dd>
+    <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -2537,7 +2413,7 @@ This section provides details for each class and property defined by Salmon Doma
      has range
     </dt>
     <dd>
-     <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>
+     <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
     </dd>
    </dl>
   </div>
@@ -2957,7 +2833,14 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/CatchContext" title="https://w3id.org/smn/CatchContext">Catch context</a></li>
   <li><a href="#/catchYear" title="https://w3id.org/smn/catchYear"> <span>catch year</span> </a></li>
   <li><a href="#/CatchYearBasis" title="https://w3id.org/smn/CatchYearBasis">Catch-year basis</a></li>
+  <li><a href="#/CountStatisticalModifier" title="https://w3id.org/smn/CountStatisticalModifier">Count</a></li>
+  <li><a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a></li>
   <li><a href="#/EuropeanAgeNotation" title="https://w3id.org/smn/EuropeanAgeNotation">European age notation</a></li>
+  <li><a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a></li>
+  <li><a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a></li>
+  <li><a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a></li>
+  <li><a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a></li>
+  <li><a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a></li>
   <li><a href="#/FreshwaterAgeDimension" title="https://w3id.org/smn/FreshwaterAgeDimension">Freshwater-age dimension</a></li>
   <li><a href="#/GilbertRichAgeNotation" title="https://w3id.org/smn/GilbertRichAgeNotation">Gilbert-Rich age notation</a></li>
   <li><a href="#/HatcheryOrigin" title="https://w3id.org/smn/HatcheryOrigin">Hatchery-origin</a></li>
@@ -2965,19 +2848,27 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/LifePhase" title="https://w3id.org/smn/LifePhase">Life phase</a></li>
   <li><a href="#/LifePhaseScheme" title="https://w3id.org/smn/LifePhaseScheme">Life phase scheme</a></li>
   <li><a href="#/MainstemPhase" title="https://w3id.org/smn/MainstemPhase">Mainstem phase</a></li>
+  <li><a href="#/MaximumStatisticalModifier" title="https://w3id.org/smn/MaximumStatisticalModifier">Maximum</a></li>
+  <li><a href="#/MeanStatisticalModifier" title="https://w3id.org/smn/MeanStatisticalModifier">Mean</a></li>
   <li><a href="#/MeasurementContext" title="https://w3id.org/smn/MeasurementContext">Measurement context</a></li>
   <li><a href="#/MeasurementContextScheme" title="https://w3id.org/smn/MeasurementContextScheme">Measurement context scheme</a></li>
+  <li><a href="#/MedianStatisticalModifier" title="https://w3id.org/smn/MedianStatisticalModifier">Median</a></li>
+  <li><a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a></li>
+  <li><a href="#/MinimumStatisticalModifier" title="https://w3id.org/smn/MinimumStatisticalModifier">Minimum</a></li>
   <li><a href="#/NaturalOrigin" title="https://w3id.org/smn/NaturalOrigin">Natural-origin</a></li>
   <li><a href="#/OceanPhase" title="https://w3id.org/smn/OceanPhase">Ocean phase</a></li>
   <li><a href="#/OceanAgeDimension" title="https://w3id.org/smn/OceanAgeDimension">Ocean-age dimension</a></li>
+  <li><a href="#/PeakStatisticalModifier" title="https://w3id.org/smn/PeakStatisticalModifier">Peak</a></li>
   <li><a href="#/returnYear" title="https://w3id.org/smn/returnYear"> <span>return year</span> </a></li>
   <li><a href="#/ReturnYearBasis" title="https://w3id.org/smn/ReturnYearBasis">Return-year basis</a></li>
   <li><a href="#/RunContext" title="https://w3id.org/smn/RunContext">Run context</a></li>
   <li><a href="#/SalmonOrigin" title="https://w3id.org/smn/SalmonOrigin">Salmon origin</a></li>
   <li><a href="#/SalmonOriginScheme" title="https://w3id.org/smn/SalmonOriginScheme">Salmon origin scheme</a></li>
   <li><a href="#/SpawnerStageContext" title="https://w3id.org/smn/SpawnerStageContext">Spawner stage context</a></li>
+  <li><a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a></li>
   <li><a href="#/SurvivalOrMortalityContext" title="https://w3id.org/smn/SurvivalOrMortalityContext">Survival or mortality context</a></li>
   <li><a href="#/TerminalPhase" title="https://w3id.org/smn/TerminalPhase">Terminal phase</a></li>
+  <li><a href="#/TotalStatisticalModifier" title="https://w3id.org/smn/TotalStatisticalModifier">Total</a></li>
   <li><a href="#/TotalAgeDimension" title="https://w3id.org/smn/TotalAgeDimension">Total-age dimension</a></li>
   <li><a href="#/YearBasis" title="https://w3id.org/smn/YearBasis">Year basis</a></li>
   <li><a href="#/YearBasisScheme" title="https://w3id.org/smn/YearBasisScheme">Year basis scheme</a></li>
@@ -4236,6 +4127,105 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="/CountStatisticalModifier">
+  <h3>Count<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/CountStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the number of summarized observations or individuals, as counted rather than estimated.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the number of summarized observations or individuals, as counted rather than estimated."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Count"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/EnumerationMethod">
+  <h3>Enumeration method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/EnumerationMethod</p>
+  <div class="comment">
+   <span class="markdown">A method used to enumerate or count salmon in the field.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="definedBy">
+   <dt>
+    Source
+   </dt>
+   <dd>
+    GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod.
+   </dd>
+   <dd>
+    <a href="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl">https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://purl.obolibrary.org/obo/IAO_0000119" target="_blank" title="http://purl.obolibrary.org/obo/IAO_0000119">I A O 0000119</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en</span>
+   </dd>
+   <dd>
+    <a href="http://purl.org/dc/terms/source" target="_blank" title="http://purl.org/dc/terms/source">source</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl" target="_blank" title="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl">gcdfo.ttl</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"A method used to enumerate or count salmon in the field."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Enumeration method"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/EuropeanAgeNotation">
   <h3>European age notation<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/EuropeanAgeNotation</p>
@@ -4297,6 +4287,181 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#scopeNote" target="_blank" title="http://www.w3.org/2004/02/skos/core#scopeNote">scope Note</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"For example, 1.2 represents freshwater-age value 1 and ocean-age value 2 when the source declares European notation."@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/FishForkLengthMeasurementMethod">
+  <h3>Fish fork-length measurement method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/FishForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fish fork-length measurement method"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/FishLengthMeasurementMethod">
+  <h3>Fish length measurement method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fish length measurement method"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/ForkLengthMeasurementFieldMethod">
+  <h3>Fork-length field method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementFieldMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fork-length field method"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/ForkLengthMeasurementLabMethod">
+  <h3>Fork-length lab method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementLabMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fork-length lab method"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/ForkLengthMeasurementMethod">
+  <h3>Fork-length measurement method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fork-length measurement method"@en</span>
    </dd>
   </dl>
  </div>
@@ -4694,6 +4859,94 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="/MaximumStatisticalModifier">
+  <h3>Maximum<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MaximumStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the maximum of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/maximum" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/maximum">maximum</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the maximum of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Maximum"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MeanStatisticalModifier">
+  <h3>Mean<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MeanStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the arithmetic mean of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/average" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/average">average</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the arithmetic mean of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Mean"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/MeasurementContext">
   <h3>Measurement context<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/MeasurementContext</p>
@@ -4795,6 +5048,132 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Measurement context scheme"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MedianStatisticalModifier">
+  <h3>Median<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MedianStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the median of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/median" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/median">median</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the median of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Median"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MethodScheme">
+  <h3>Method scheme<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MethodScheme</p>
+  <div class="comment">
+   <span class="markdown">Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11).</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#ConceptScheme">Concept Scheme</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11)."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Method scheme"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MinimumStatisticalModifier">
+  <h3>Minimum<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MinimumStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the minimum of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/minimum" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/minimum">minimum</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the minimum of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Minimum"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -4969,6 +5348,47 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Ocean-age dimension"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/PeakStatisticalModifier">
+  <h3>Peak<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/PeakStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Peak"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -5265,6 +5685,59 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="/StatisticalModifierScheme">
+  <h3>Statistical modifier scheme<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/StatisticalModifierScheme</p>
+  <div class="comment">
+   <span class="markdown">Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#ConceptScheme">Concept Scheme</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/CountStatisticalModifier" title="https://w3id.org/smn/CountStatisticalModifier">Count</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MaximumStatisticalModifier" title="https://w3id.org/smn/MaximumStatisticalModifier">Maximum</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MeanStatisticalModifier" title="https://w3id.org/smn/MeanStatisticalModifier">Mean</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MedianStatisticalModifier" title="https://w3id.org/smn/MedianStatisticalModifier">Median</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MinimumStatisticalModifier" title="https://w3id.org/smn/MinimumStatisticalModifier">Minimum</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/PeakStatisticalModifier" title="https://w3id.org/smn/PeakStatisticalModifier">Peak</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/TotalStatisticalModifier" title="https://w3id.org/smn/TotalStatisticalModifier">Total</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Statistical modifier scheme"@en</span>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/SurvivalOrMortalityContext">
   <h3>Survival or mortality context<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SurvivalOrMortalityContext</p>
@@ -5372,6 +5845,50 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Terminal phase"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/TotalStatisticalModifier">
+  <h3>Total<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/TotalStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/cumulative" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/cumulative">cumulative</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Total"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -5617,6 +6134,13 @@ This section provides details for each class and property defined by Salmon Doma
 <li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://www.w3.org/ns/sosa/ObservableProperty</li>
 </ul>
 </li>
+<li><a href="#/AggregatedMeasurement">https://w3id.org/smn/AggregatedMeasurement</a>
+<ul>
+<li>Added: rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en</li>
+</ul>
+<ul>
+<li></ul>
+</li>
 <li><a href="#/CatchAbundance">https://w3id.org/smn/CatchAbundance</a>
 <ul>
 <li>Added: rdfs:seeAlso https://w3id.org/smn/Abundance</li>
@@ -5634,17 +6158,18 @@ This section provides details for each class and property defined by Salmon Doma
 <li>Deleted: <http://purl.obolibrary.org/obo/IAO_0000115> "A local interbreeding group within a species; in salmon systems, typically corresponding to a spawning-site-scale biological unit."@en</li>
 </ul>
 </li>
-<li><a href="#/EnumerationMethod">https://w3id.org/smn/EnumerationMethod</a>
-<ul>
-<li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en</li>
-<li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
-</ul>
-</li>
 <li><a href="#/EscapementSurveyEvent">https://w3id.org/smn/EscapementSurveyEvent</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementSurveyEvent."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
 </ul>
+</li>
+<li><a href="#/FishLengthMeasurementType">https://w3id.org/smn/FishLengthMeasurementType</a>
+<ul>
+<li><li>Added: rdfs:comment "The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class."@en</li>
+</ul>
+<ul>
+<li></ul>
 </li>
 <li><a href="#/ObservedRateOrAbundance">https://w3id.org/smn/ObservedRateOrAbundance</a>
 <ul>
@@ -5726,11 +6251,31 @@ This section provides details for each class and property defined by Salmon Doma
 </li>
 <li><a href="#https://w3id.org/iadopt/ont/Property">https://w3id.org/iadopt/ont/Property</a>
 </li>
+<li><a href="#/EnumerationMethod">https://w3id.org/smn/EnumerationMethod</a>
+</li>
 <li><a href="#/EscapementMeasurement">https://w3id.org/smn/EscapementMeasurement</a>
+</li>
+<li><a href="#/FishForkLengthMeasurementMethod">https://w3id.org/smn/FishForkLengthMeasurementMethod</a>
+</li>
+<li><a href="#/FishLengthMeasurementMethod">https://w3id.org/smn/FishLengthMeasurementMethod</a>
+</li>
+<li><a href="#/ForkLengthMeasurementFieldMethod">https://w3id.org/smn/ForkLengthMeasurementFieldMethod</a>
+</li>
+<li><a href="#/ForkLengthMeasurementLabMethod">https://w3id.org/smn/ForkLengthMeasurementLabMethod</a>
+</li>
+<li><a href="#/ForkLengthMeasurementMethod">https://w3id.org/smn/ForkLengthMeasurementMethod</a>
 </li>
 </ul></details><h3 id="changeProp" class="list">Object Properties</h3>
 <details><summary><u>Modified object properties</u></summary>
-<ul><li><a href="#/demeOf">https://w3id.org/smn/demeOf</a>
+<ul><li><a href="#/basedOn">https://w3id.org/smn/basedOn</a>
+<ul>
+<li>Added: Range http://www.w3.org/ns/sosa/Procedure</li>
+</ul>
+<ul>
+<li>Deleted: Range https://w3id.org/smn/EnumerationMethod</li>
+</ul>
+</li>
+<li><a href="#/demeOf">https://w3id.org/smn/demeOf</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.8, term smn:demeOf."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.8/gcdfo.ttl</li>

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -680,7 +680,7 @@ This section provides details for each class and property defined by Salmon Doma
   <h3>Aggregated measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/AggregatedMeasurement</p>
   <div class="comment">
-   <span class="markdown">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod).</span>
+   <span class="markdown">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -6136,7 +6136,7 @@ This section provides details for each class and property defined by Salmon Doma
 </li>
 <li><a href="#/AggregatedMeasurement">https://w3id.org/smn/AggregatedMeasurement</a>
 <ul>
-<li>Added: rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en</li>
+<li>Added: rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals."@en</li>
 </ul>
 <ul>
 <li></ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,9 +129,6 @@ This ontology has the following classes and properties.</span>
       <a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a>
    </li>
    <li>
-      <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a>
-   </li>
-   <li>
       <a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a>
    </li>
    <li>
@@ -152,14 +149,7 @@ This ontology has the following classes and properties.</span>
       </a>
    </li>
    <li>
-      <a href="#/FishForkLengthMeasurementMethod"
-         title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a>
-   </li>
-   <li>
       <a href="#/FishLength" title="https://w3id.org/smn/FishLength">Fish length</a>
-   </li>
-   <li>
-      <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a>
    </li>
    <li>
       <a href="#/FishLengthMeasurementType" title="https://w3id.org/smn/FishLengthMeasurementType">Fish length measurement type</a>
@@ -174,18 +164,7 @@ This ontology has the following classes and properties.</span>
       <a href="#/forkLength" title="https://w3id.org/smn/forkLength">Fork length</a>
    </li>
    <li>
-      <a href="#/ForkLengthMeasurementFieldMethod"
-         title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a>
-   </li>
-   <li>
-      <a href="#/ForkLengthMeasurementLabMethod"
-         title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a>
-   </li>
-   <li>
       <a href="#/ForkLengthMeasurement" title="https://w3id.org/smn/ForkLengthMeasurement">Fork-length measurement</a>
-   </li>
-   <li>
-      <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a>
    </li>
    <li>
       <a href="#/fusiform" title="https://w3id.org/smn/fusiform">Fusiform</a>
@@ -221,8 +200,7 @@ This ontology has the following classes and properties.</span>
       <a href="#/ModelMeasurement" title="https://w3id.org/smn/ModelMeasurement">Model measurement</a>
    </li>
    <li>
-      <a href="#/MorphologicalCharacteristic"
-         title="https://w3id.org/smn/MorphologicalCharacteristic">Morphological characteristic</a>
+      <a href="#/MorphologicalCharacteristic" title="https://w3id.org/smn/MorphologicalCharacteristic">Morphological characteristic</a>
    </li>
    <li>
       <a href="#http://purl.obolibrary.org/obo/NCBITaxon_8018" title="http://purl.obolibrary.org/obo/NCBITaxon_8018">
@@ -459,7 +437,33 @@ This ontology has the following classes and properties.</span>
       <a href="#/CatchYearBasis" title="https://w3id.org/smn/CatchYearBasis">Catch-year basis</a>
    </li>
    <li>
+      <a href="#/CountStatisticalModifier" title="https://w3id.org/smn/CountStatisticalModifier">Count</a>
+   </li>
+   <li>
+      <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a>
+   </li>
+   <li>
       <a href="#/EuropeanAgeNotation" title="https://w3id.org/smn/EuropeanAgeNotation">European age notation</a>
+   </li>
+   <li>
+      <a href="#/FishForkLengthMeasurementMethod"
+         title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a>
+   </li>
+   <li>
+      <a href="#/FishLengthMeasurementMethod"
+         title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a>
+   </li>
+   <li>
+      <a href="#/ForkLengthMeasurementFieldMethod"
+         title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a>
+   </li>
+   <li>
+      <a href="#/ForkLengthMeasurementLabMethod"
+         title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a>
+   </li>
+   <li>
+      <a href="#/ForkLengthMeasurementMethod"
+         title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a>
    </li>
    <li>
       <a href="#/FreshwaterAgeDimension" title="https://w3id.org/smn/FreshwaterAgeDimension">Freshwater-age dimension</a>
@@ -483,10 +487,25 @@ This ontology has the following classes and properties.</span>
       <a href="#/MainstemPhase" title="https://w3id.org/smn/MainstemPhase">Mainstem phase</a>
    </li>
    <li>
+      <a href="#/MaximumStatisticalModifier" title="https://w3id.org/smn/MaximumStatisticalModifier">Maximum</a>
+   </li>
+   <li>
+      <a href="#/MeanStatisticalModifier" title="https://w3id.org/smn/MeanStatisticalModifier">Mean</a>
+   </li>
+   <li>
       <a href="#/MeasurementContext" title="https://w3id.org/smn/MeasurementContext">Measurement context</a>
    </li>
    <li>
       <a href="#/MeasurementContextScheme" title="https://w3id.org/smn/MeasurementContextScheme">Measurement context scheme</a>
+   </li>
+   <li>
+      <a href="#/MedianStatisticalModifier" title="https://w3id.org/smn/MedianStatisticalModifier">Median</a>
+   </li>
+   <li>
+      <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a>
+   </li>
+   <li>
+      <a href="#/MinimumStatisticalModifier" title="https://w3id.org/smn/MinimumStatisticalModifier">Minimum</a>
    </li>
    <li>
       <a href="#/NaturalOrigin" title="https://w3id.org/smn/NaturalOrigin">Natural-origin</a>
@@ -496,6 +515,9 @@ This ontology has the following classes and properties.</span>
    </li>
    <li>
       <a href="#/OceanAgeDimension" title="https://w3id.org/smn/OceanAgeDimension">Ocean-age dimension</a>
+   </li>
+   <li>
+      <a href="#/PeakStatisticalModifier" title="https://w3id.org/smn/PeakStatisticalModifier">Peak</a>
    </li>
    <li>
       <a href="#/returnYear" title="https://w3id.org/smn/returnYear">
@@ -518,10 +540,16 @@ This ontology has the following classes and properties.</span>
       <a href="#/SpawnerStageContext" title="https://w3id.org/smn/SpawnerStageContext">Spawner stage context</a>
    </li>
    <li>
+      <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a>
+   </li>
+   <li>
       <a href="#/SurvivalOrMortalityContext" title="https://w3id.org/smn/SurvivalOrMortalityContext">Survival or mortality context</a>
    </li>
    <li>
       <a href="#/TerminalPhase" title="https://w3id.org/smn/TerminalPhase">Terminal phase</a>
+   </li>
+   <li>
+      <a href="#/TotalStatisticalModifier" title="https://w3id.org/smn/TotalStatisticalModifier">Total</a>
    </li>
    <li>
       <a href="#/TotalAgeDimension" title="https://w3id.org/smn/TotalAgeDimension">Total-age dimension</a>
@@ -558,24 +586,18 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/Deme" title="https://w3id.org/smn/Deme">Deme</a></li>
   <li><a href="#https://w3id.org/iadopt/ont/Entity" title="https://w3id.org/iadopt/ont/Entity"> <span>Entity</span> </a></li>
   <li><a href="#/Entity" title="https://w3id.org/smn/Entity">Entity</a></li>
-  <li><a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a></li>
   <li><a href="#/Escapement" title="https://w3id.org/smn/Escapement">Escapement</a></li>
   <li><a href="#/EscapementEstimate" title="https://w3id.org/smn/EscapementEstimate">Escapement estimate</a></li>
   <li><a href="#/EscapementSurveyEvent" title="https://w3id.org/smn/EscapementSurveyEvent">Escapement survey event</a></li>
   <li><a href="#/EventType" title="https://w3id.org/smn/EventType">Event type</a></li>
   <li><a href="#/ExploitationRate" title="https://w3id.org/smn/ExploitationRate">Exploitation rate</a></li>
   <li><a href="#http://www.opengis.net/ont/geosparql#Feature" title="http://www.opengis.net/ont/geosparql#Feature"> <span>Feature</span> </a></li>
-  <li><a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a></li>
   <li><a href="#/FishLength" title="https://w3id.org/smn/FishLength">Fish length</a></li>
-  <li><a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a></li>
   <li><a href="#/FishLengthMeasurementType" title="https://w3id.org/smn/FishLengthMeasurementType">Fish length measurement type</a></li>
   <li><a href="#/FishWeight" title="https://w3id.org/smn/FishWeight">Fish weight</a></li>
   <li><a href="#/FishingType" title="https://w3id.org/smn/FishingType">Fishing type</a></li>
   <li><a href="#/forkLength" title="https://w3id.org/smn/forkLength">Fork length</a></li>
-  <li><a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a></li>
-  <li><a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a></li>
   <li><a href="#/ForkLengthMeasurement" title="https://w3id.org/smn/ForkLengthMeasurement">Fork-length measurement</a></li>
-  <li><a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a></li>
   <li><a href="#/fusiform" title="https://w3id.org/smn/fusiform">Fusiform</a></li>
   <li><a href="#/GeographicFeature" title="https://w3id.org/smn/GeographicFeature">Geographic feature</a></li>
   <li><a href="#/HabitatUnit" title="https://w3id.org/smn/HabitatUnit">Habitat unit</a></li>
@@ -657,6 +679,9 @@ This section provides details for each class and property defined by Salmon Doma
  <div class="entity" id="/AggregatedMeasurement">
   <h3>Aggregated measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/AggregatedMeasurement</p>
+  <div class="comment">
+   <span class="markdown">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod).</span>
+  </div>
   <dl class="definedBy">
    <dt>
     Is defined by
@@ -893,46 +918,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/EnumerationMethod">
-  <h3>Enumeration method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/EnumerationMethod</p>
-  <div class="comment">
-   <span class="markdown">A method used to enumerate or count salmon in the field</span>
-  </div>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="definedBy">
-   <dt>
-    Source
-   </dt>
-   <dd>
-    GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod.
-   </dd>
-   <dd>
-    <a href="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl">https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    is in range of
-   </dt>
-   <dd>
-    <a href="#/basedOn" title="https://w3id.org/smn/basedOn">based on</a> <sup class="type-op" title="object property">op</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/Escapement">
   <h3>Escapement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/Escapement</p>
@@ -1125,32 +1110,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/FishForkLengthMeasurementMethod">
-  <h3>Fish fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/FishForkLengthMeasurementMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/FishLength">
   <h3>Fish length<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLength</p>
@@ -1177,35 +1136,12 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/FishLengthMeasurementMethod">
-  <h3>Fish length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/FishLengthMeasurementType">
   <h3>Fish length measurement type<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementType</p>
+  <div class="comment">
+   <span class="markdown">The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class.</span>
+  </div>
   <dl class="definedBy">
    <dt>
     Is defined by
@@ -1295,46 +1231,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
- <div class="entity" id="/ForkLengthMeasurementFieldMethod">
-  <h3>Fork-length field method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementFieldMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="/ForkLengthMeasurementLabMethod">
-  <h3>Fork-length lab method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementLabMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
  <div class="entity" id="/ForkLengthMeasurement">
   <h3>Fork-length measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurement</p>
@@ -1352,32 +1248,6 @@ This section provides details for each class and property defined by Salmon Doma
    </dt>
    <dd>
     <a href="#/FishLengthMeasurementType" title="https://w3id.org/smn/FishLengthMeasurementType">Fish length measurement type</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-  </dl>
- </div>
- <div class="entity" id="/ForkLengthMeasurementMethod">
-  <h3>Fork-length measurement method<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
-  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementMethod</p>
-  <dl class="definedBy">
-   <dt>
-    Is defined by
-   </dt>
-   <dd>
-    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
-   </dd>
-  </dl>
-  <dl class="description">
-   <dt>
-    has super-classes
-   </dt>
-   <dd>
-    <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-c" title="class">c</sup>
-   </dd>
-   <dt>
-    has sub-classes
-   </dt>
-   <dd>
-    <a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a> <sup class="type-c" title="class">c</sup>, <a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a> <sup class="type-c" title="class">c</sup>
    </dd>
   </dl>
  </div>
@@ -1898,10 +1768,16 @@ This section provides details for each class and property defined by Salmon Doma
   <p><strong>IRI:</strong> http://www.w3.org/ns/sosa/Procedure</p>
   <dl class="description">
    <dt>
-    has sub-classes
+    is in range of
    </dt>
    <dd>
-    <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>, <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-c" title="class">c</sup>
+    <a href="#/basedOn" title="https://w3id.org/smn/basedOn">based on</a> <sup class="type-op" title="object property">op</sup>
+   </dd>
+   <dt>
+    has members
+   </dt>
+   <dd>
+    <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a> <sup class="type-ni" title="named individual">ni</sup>, <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -2537,7 +2413,7 @@ This section provides details for each class and property defined by Salmon Doma
      has range
     </dt>
     <dd>
-     <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-c" title="class">c</sup>
+     <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
     </dd>
    </dl>
   </div>
@@ -2957,7 +2833,14 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/CatchContext" title="https://w3id.org/smn/CatchContext">Catch context</a></li>
   <li><a href="#/catchYear" title="https://w3id.org/smn/catchYear"> <span>catch year</span> </a></li>
   <li><a href="#/CatchYearBasis" title="https://w3id.org/smn/CatchYearBasis">Catch-year basis</a></li>
+  <li><a href="#/CountStatisticalModifier" title="https://w3id.org/smn/CountStatisticalModifier">Count</a></li>
+  <li><a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a></li>
   <li><a href="#/EuropeanAgeNotation" title="https://w3id.org/smn/EuropeanAgeNotation">European age notation</a></li>
+  <li><a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a></li>
+  <li><a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a></li>
+  <li><a href="#/ForkLengthMeasurementFieldMethod" title="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">Fork-length field method</a></li>
+  <li><a href="#/ForkLengthMeasurementLabMethod" title="https://w3id.org/smn/ForkLengthMeasurementLabMethod">Fork-length lab method</a></li>
+  <li><a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a></li>
   <li><a href="#/FreshwaterAgeDimension" title="https://w3id.org/smn/FreshwaterAgeDimension">Freshwater-age dimension</a></li>
   <li><a href="#/GilbertRichAgeNotation" title="https://w3id.org/smn/GilbertRichAgeNotation">Gilbert-Rich age notation</a></li>
   <li><a href="#/HatcheryOrigin" title="https://w3id.org/smn/HatcheryOrigin">Hatchery-origin</a></li>
@@ -2965,19 +2848,27 @@ This section provides details for each class and property defined by Salmon Doma
   <li><a href="#/LifePhase" title="https://w3id.org/smn/LifePhase">Life phase</a></li>
   <li><a href="#/LifePhaseScheme" title="https://w3id.org/smn/LifePhaseScheme">Life phase scheme</a></li>
   <li><a href="#/MainstemPhase" title="https://w3id.org/smn/MainstemPhase">Mainstem phase</a></li>
+  <li><a href="#/MaximumStatisticalModifier" title="https://w3id.org/smn/MaximumStatisticalModifier">Maximum</a></li>
+  <li><a href="#/MeanStatisticalModifier" title="https://w3id.org/smn/MeanStatisticalModifier">Mean</a></li>
   <li><a href="#/MeasurementContext" title="https://w3id.org/smn/MeasurementContext">Measurement context</a></li>
   <li><a href="#/MeasurementContextScheme" title="https://w3id.org/smn/MeasurementContextScheme">Measurement context scheme</a></li>
+  <li><a href="#/MedianStatisticalModifier" title="https://w3id.org/smn/MedianStatisticalModifier">Median</a></li>
+  <li><a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a></li>
+  <li><a href="#/MinimumStatisticalModifier" title="https://w3id.org/smn/MinimumStatisticalModifier">Minimum</a></li>
   <li><a href="#/NaturalOrigin" title="https://w3id.org/smn/NaturalOrigin">Natural-origin</a></li>
   <li><a href="#/OceanPhase" title="https://w3id.org/smn/OceanPhase">Ocean phase</a></li>
   <li><a href="#/OceanAgeDimension" title="https://w3id.org/smn/OceanAgeDimension">Ocean-age dimension</a></li>
+  <li><a href="#/PeakStatisticalModifier" title="https://w3id.org/smn/PeakStatisticalModifier">Peak</a></li>
   <li><a href="#/returnYear" title="https://w3id.org/smn/returnYear"> <span>return year</span> </a></li>
   <li><a href="#/ReturnYearBasis" title="https://w3id.org/smn/ReturnYearBasis">Return-year basis</a></li>
   <li><a href="#/RunContext" title="https://w3id.org/smn/RunContext">Run context</a></li>
   <li><a href="#/SalmonOrigin" title="https://w3id.org/smn/SalmonOrigin">Salmon origin</a></li>
   <li><a href="#/SalmonOriginScheme" title="https://w3id.org/smn/SalmonOriginScheme">Salmon origin scheme</a></li>
   <li><a href="#/SpawnerStageContext" title="https://w3id.org/smn/SpawnerStageContext">Spawner stage context</a></li>
+  <li><a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a></li>
   <li><a href="#/SurvivalOrMortalityContext" title="https://w3id.org/smn/SurvivalOrMortalityContext">Survival or mortality context</a></li>
   <li><a href="#/TerminalPhase" title="https://w3id.org/smn/TerminalPhase">Terminal phase</a></li>
+  <li><a href="#/TotalStatisticalModifier" title="https://w3id.org/smn/TotalStatisticalModifier">Total</a></li>
   <li><a href="#/TotalAgeDimension" title="https://w3id.org/smn/TotalAgeDimension">Total-age dimension</a></li>
   <li><a href="#/YearBasis" title="https://w3id.org/smn/YearBasis">Year basis</a></li>
   <li><a href="#/YearBasisScheme" title="https://w3id.org/smn/YearBasisScheme">Year basis scheme</a></li>
@@ -4236,6 +4127,105 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="/CountStatisticalModifier">
+  <h3>Count<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/CountStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the number of summarized observations or individuals, as counted rather than estimated.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the number of summarized observations or individuals, as counted rather than estimated."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Count"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/EnumerationMethod">
+  <h3>Enumeration method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/EnumerationMethod</p>
+  <div class="comment">
+   <span class="markdown">A method used to enumerate or count salmon in the field.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="definedBy">
+   <dt>
+    Source
+   </dt>
+   <dd>
+    GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod.
+   </dd>
+   <dd>
+    <a href="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl">https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://purl.obolibrary.org/obo/IAO_0000119" target="_blank" title="http://purl.obolibrary.org/obo/IAO_0000119">I A O 0000119</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en</span>
+   </dd>
+   <dd>
+    <a href="http://purl.org/dc/terms/source" target="_blank" title="http://purl.org/dc/terms/source">source</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl" target="_blank" title="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl">gcdfo.ttl</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"A method used to enumerate or count salmon in the field."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Enumeration method"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/EuropeanAgeNotation">
   <h3>European age notation<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/EuropeanAgeNotation</p>
@@ -4297,6 +4287,181 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#scopeNote" target="_blank" title="http://www.w3.org/2004/02/skos/core#scopeNote">scope Note</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"For example, 1.2 represents freshwater-age value 1 and ocean-age value 2 when the source declares European notation."@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/FishForkLengthMeasurementMethod">
+  <h3>Fish fork-length measurement method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/FishForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fish fork-length measurement method"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/FishLengthMeasurementMethod">
+  <h3>Fish length measurement method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/FishLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fish length measurement method"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/ForkLengthMeasurementFieldMethod">
+  <h3>Fork-length field method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementFieldMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fork-length field method"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/ForkLengthMeasurementLabMethod">
+  <h3>Fork-length lab method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementLabMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/ForkLengthMeasurementMethod" title="https://w3id.org/smn/ForkLengthMeasurementMethod">Fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fork-length lab method"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/ForkLengthMeasurementMethod">
+  <h3>Fork-length measurement method<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/ForkLengthMeasurementMethod</p>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="#http://www.w3.org/ns/sosa/Procedure" title="http://www.w3.org/ns/sosa/Procedure">Procedure</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#broader" target="_blank" title="http://www.w3.org/2004/02/skos/core#broader">broader</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/FishForkLengthMeasurementMethod" title="https://w3id.org/smn/FishForkLengthMeasurementMethod">Fish fork-length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MethodScheme" title="https://w3id.org/smn/MethodScheme">Method scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Fork-length measurement method"@en</span>
    </dd>
   </dl>
  </div>
@@ -4694,6 +4859,94 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="/MaximumStatisticalModifier">
+  <h3>Maximum<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MaximumStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the maximum of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/maximum" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/maximum">maximum</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the maximum of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Maximum"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MeanStatisticalModifier">
+  <h3>Mean<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MeanStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the arithmetic mean of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/average" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/average">average</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the arithmetic mean of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Mean"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/MeasurementContext">
   <h3>Measurement context<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/MeasurementContext</p>
@@ -4795,6 +5048,132 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Measurement context scheme"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MedianStatisticalModifier">
+  <h3>Median<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MedianStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the median of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/median" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/median">median</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the median of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Median"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MethodScheme">
+  <h3>Method scheme<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MethodScheme</p>
+  <div class="comment">
+   <span class="markdown">Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11).</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#ConceptScheme">Concept Scheme</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11)."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/EnumerationMethod" title="https://w3id.org/smn/EnumerationMethod">Enumeration method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/FishLengthMeasurementMethod" title="https://w3id.org/smn/FishLengthMeasurementMethod">Fish length measurement method</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Method scheme"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/MinimumStatisticalModifier">
+  <h3>Minimum<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/MinimumStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the minimum of the summarized observations.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/minimum" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/minimum">minimum</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the minimum of the summarized observations."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Minimum"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -4969,6 +5348,47 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Ocean-age dimension"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/PeakStatisticalModifier">
+  <h3>Peak<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/PeakStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Peak"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -5265,6 +5685,59 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
   </dl>
  </div>
+ <div class="entity" id="/StatisticalModifierScheme">
+  <h3>Statistical modifier scheme<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/StatisticalModifierScheme</p>
+  <div class="comment">
+   <span class="markdown">Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#ConceptScheme">Concept Scheme</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/CountStatisticalModifier" title="https://w3id.org/smn/CountStatisticalModifier">Count</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MaximumStatisticalModifier" title="https://w3id.org/smn/MaximumStatisticalModifier">Maximum</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MeanStatisticalModifier" title="https://w3id.org/smn/MeanStatisticalModifier">Mean</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MedianStatisticalModifier" title="https://w3id.org/smn/MedianStatisticalModifier">Median</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/MinimumStatisticalModifier" title="https://w3id.org/smn/MinimumStatisticalModifier">Minimum</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/PeakStatisticalModifier" title="https://w3id.org/smn/PeakStatisticalModifier">Peak</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#hasTopConcept" target="_blank" title="http://www.w3.org/2004/02/skos/core#hasTopConcept">has Top Concept</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/TotalStatisticalModifier" title="https://w3id.org/smn/TotalStatisticalModifier">Total</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Statistical modifier scheme"@en</span>
+   </dd>
+  </dl>
+ </div>
  <div class="entity" id="/SurvivalOrMortalityContext">
   <h3>Survival or mortality context<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/SurvivalOrMortalityContext</p>
@@ -5372,6 +5845,50 @@ This section provides details for each class and property defined by Salmon Doma
    </dd>
    <dd>
     <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Terminal phase"@en</span>
+   </dd>
+  </dl>
+ </div>
+ <div class="entity" id="/TotalStatisticalModifier">
+  <h3>Total<sup class="type-ni" title="named individual">ni</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#namedindividuals">Named Individual ToC</a> </span></h3>
+  <p><strong>IRI:</strong> https://w3id.org/smn/TotalStatisticalModifier</p>
+  <div class="comment">
+   <span class="markdown">The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement.</span>
+  </div>
+  <dl class="definedBy">
+   <dt>
+    Is defined by
+   </dt>
+   <dd>
+    <a href="https://w3id.org/smn">https://w3id.org/smn</a>
+   </dd>
+  </dl>
+  <dl class="description">
+   <dt>
+    belongs to
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#Concept" target="_blank" title="http://www.w3.org/2004/02/skos/core#Concept">Concept</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dd>
+    <a href="https://w3id.org/iadopt/ont/StatisticalModifier" target="_blank" title="https://w3id.org/iadopt/ont/StatisticalModifier">Statistical Modifier</a> <sup class="type-c" title="class">c</sup>
+   </dd>
+   <dt>
+    has facts
+   </dt>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#closeMatch" target="_blank" title="http://www.w3.org/2004/02/skos/core#closeMatch">close Match</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="http://vocabulary.odm2.org/aggregationstatistic/cumulative" target="_blank" title="http://vocabulary.odm2.org/aggregationstatistic/cumulative">cumulative</a> <sup class="type-ep" title="external property">ep</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#definition" target="_blank" title="http://www.w3.org/2004/02/skos/core#definition">definition</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement."@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#inScheme" target="_blank" title="http://www.w3.org/2004/02/skos/core#inScheme">in Scheme</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#prefLabel" target="_blank" title="http://www.w3.org/2004/02/skos/core#prefLabel">pref Label</a> <sup class="type-ap" title="annotation property">ap</sup> <span class="literal">"Total"@en</span>
+   </dd>
+   <dd>
+    <a href="http://www.w3.org/2004/02/skos/core#topConceptOf" target="_blank" title="http://www.w3.org/2004/02/skos/core#topConceptOf">top Concept Of</a> <sup class="type-ap" title="annotation property">ap</sup> <a href="#/StatisticalModifierScheme" title="https://w3id.org/smn/StatisticalModifierScheme">Statistical modifier scheme</a> <sup class="type-ni" title="named individual">ni</sup>
    </dd>
   </dl>
  </div>
@@ -5617,6 +6134,13 @@ This section provides details for each class and property defined by Salmon Doma
 <li>Added: <http://www.w3.org/2004/02/skos/core#closeMatch> http://www.w3.org/ns/sosa/ObservableProperty</li>
 </ul>
 </li>
+<li><a href="#/AggregatedMeasurement">https://w3id.org/smn/AggregatedMeasurement</a>
+<ul>
+<li>Added: rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en</li>
+</ul>
+<ul>
+<li></ul>
+</li>
 <li><a href="#/CatchAbundance">https://w3id.org/smn/CatchAbundance</a>
 <ul>
 <li>Added: rdfs:seeAlso https://w3id.org/smn/Abundance</li>
@@ -5634,17 +6158,18 @@ This section provides details for each class and property defined by Salmon Doma
 <li>Deleted: <http://purl.obolibrary.org/obo/IAO_0000115> "A local interbreeding group within a species; in salmon systems, typically corresponding to a spawning-site-scale biological unit."@en</li>
 </ul>
 </li>
-<li><a href="#/EnumerationMethod">https://w3id.org/smn/EnumerationMethod</a>
-<ul>
-<li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en</li>
-<li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
-</ul>
-</li>
 <li><a href="#/EscapementSurveyEvent">https://w3id.org/smn/EscapementSurveyEvent</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EscapementSurveyEvent."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl</li>
 </ul>
+</li>
+<li><a href="#/FishLengthMeasurementType">https://w3id.org/smn/FishLengthMeasurementType</a>
+<ul>
+<li><li>Added: rdfs:comment "The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class."@en</li>
+</ul>
+<ul>
+<li></ul>
 </li>
 <li><a href="#/ObservedRateOrAbundance">https://w3id.org/smn/ObservedRateOrAbundance</a>
 <ul>
@@ -5726,11 +6251,31 @@ This section provides details for each class and property defined by Salmon Doma
 </li>
 <li><a href="#https://w3id.org/iadopt/ont/Property">https://w3id.org/iadopt/ont/Property</a>
 </li>
+<li><a href="#/EnumerationMethod">https://w3id.org/smn/EnumerationMethod</a>
+</li>
 <li><a href="#/EscapementMeasurement">https://w3id.org/smn/EscapementMeasurement</a>
+</li>
+<li><a href="#/FishForkLengthMeasurementMethod">https://w3id.org/smn/FishForkLengthMeasurementMethod</a>
+</li>
+<li><a href="#/FishLengthMeasurementMethod">https://w3id.org/smn/FishLengthMeasurementMethod</a>
+</li>
+<li><a href="#/ForkLengthMeasurementFieldMethod">https://w3id.org/smn/ForkLengthMeasurementFieldMethod</a>
+</li>
+<li><a href="#/ForkLengthMeasurementLabMethod">https://w3id.org/smn/ForkLengthMeasurementLabMethod</a>
+</li>
+<li><a href="#/ForkLengthMeasurementMethod">https://w3id.org/smn/ForkLengthMeasurementMethod</a>
 </li>
 </ul></details><h3 id="changeProp" class="list">Object Properties</h3>
 <details><summary><u>Modified object properties</u></summary>
-<ul><li><a href="#/demeOf">https://w3id.org/smn/demeOf</a>
+<ul><li><a href="#/basedOn">https://w3id.org/smn/basedOn</a>
+<ul>
+<li>Added: Range http://www.w3.org/ns/sosa/Procedure</li>
+</ul>
+<ul>
+<li>Deleted: Range https://w3id.org/smn/EnumerationMethod</li>
+</ul>
+</li>
+<li><a href="#/demeOf">https://w3id.org/smn/demeOf</a>
 <ul>
 <li>Added: <http://purl.obolibrary.org/obo/IAO_0000119> "GC DFO Salmon Ontology release 0.0.8, term smn:demeOf."@en</li>
 <li>Added: <http://purl.org/dc/terms/source> https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.8/gcdfo.ttl</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -680,7 +680,7 @@ This section provides details for each class and property defined by Salmon Doma
   <h3>Aggregated measurement<sup class="type-c" title="class">c</sup> <span class="backlink"> back to <a href="#toc">ToC</a> or <a href="#classes">Class ToC</a> </span></h3>
   <p><strong>IRI:</strong> https://w3id.org/smn/AggregatedMeasurement</p>
   <div class="comment">
-   <span class="markdown">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod).</span>
+   <span class="markdown">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals.</span>
   </div>
   <dl class="definedBy">
    <dt>
@@ -6136,7 +6136,7 @@ This section provides details for each class and property defined by Salmon Doma
 </li>
 <li><a href="#/AggregatedMeasurement">https://w3id.org/smn/AggregatedMeasurement</a>
 <ul>
-<li>Added: rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en</li>
+<li>Added: rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals."@en</li>
 </ul>
 <ul>
 <li></ul>

--- a/docs/migrations/smn-internal-renames.csv
+++ b/docs/migrations/smn-internal-renames.csv
@@ -1,2 +1,8 @@
 old_iri,new_iri,module,status,notes
 https://w3id.org/smn/EscapementMeasurement,https://w3id.org/smn/EscapementEstimate,02-observation-measurement.ttl,renamed 2026-08-13,"F6: the class is an IAO measurement datum, and every other *Measurement class is an activity; direct replacement per CONVENTIONS section 9 alpha posture"
+https://w3id.org/smn/EnumerationMethod,https://w3id.org/smn/EnumerationMethod,07-controlled-vocabularies.ttl,retyped 2026-08-13,"methods-as-SKOS: owl:Class subClassOf sosa:Procedure -> skos:Concept in smn:MethodScheme, instance-typed sosa:Procedure; IRI unchanged"
+https://w3id.org/smn/FishLengthMeasurementMethod,https://w3id.org/smn/FishLengthMeasurementMethod,07-controlled-vocabularies.ttl,retyped 2026-08-13,"methods-as-SKOS retype; IRI unchanged"
+https://w3id.org/smn/FishForkLengthMeasurementMethod,https://w3id.org/smn/FishForkLengthMeasurementMethod,07-controlled-vocabularies.ttl,retyped 2026-08-13,"methods-as-SKOS retype; IRI unchanged"
+https://w3id.org/smn/ForkLengthMeasurementMethod,https://w3id.org/smn/ForkLengthMeasurementMethod,07-controlled-vocabularies.ttl,retyped 2026-08-13,"methods-as-SKOS retype; IRI unchanged"
+https://w3id.org/smn/ForkLengthMeasurementFieldMethod,https://w3id.org/smn/ForkLengthMeasurementFieldMethod,07-controlled-vocabularies.ttl,retyped 2026-08-13,"methods-as-SKOS retype; IRI unchanged"
+https://w3id.org/smn/ForkLengthMeasurementLabMethod,https://w3id.org/smn/ForkLengthMeasurementLabMethod,07-controlled-vocabularies.ttl,retyped 2026-08-13,"methods-as-SKOS retype; IRI unchanged"

--- a/docs/smn.jsonld
+++ b/docs/smn.jsonld
@@ -1273,7 +1273,7 @@
     "http://www.w3.org/2000/01/rdf-schema#comment": [
       {
         "@language": "en",
-        "@value": "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."
+        "@value": "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals."
       }
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [

--- a/docs/smn.jsonld
+++ b/docs/smn.jsonld
@@ -27,7 +27,7 @@
     ],
     "http://www.w3.org/2002/07/owl#someValuesFrom": [
       {
-        "@id": "https://w3id.org/smn/EnumerationMethod"
+        "@id": "http://www.w3.org/ns/sosa/Procedure"
       }
     ]
   },
@@ -107,7 +107,7 @@
     ],
     "http://www.w3.org/2002/07/owl#someValuesFrom": [
       {
-        "@id": "https://w3id.org/smn/FishLengthMeasurementMethod"
+        "@id": "http://www.w3.org/ns/sosa/Procedure"
       }
     ]
   },
@@ -1270,6 +1270,12 @@
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
     ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@language": "en",
+        "@value": "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."
+      }
+    ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
@@ -1542,6 +1548,40 @@
     ]
   },
   {
+    "@id": "https://w3id.org/smn/CountStatisticalModifier",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "https://w3id.org/iadopt/ont/StatisticalModifier"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The reported value is the number of summarized observations or individuals, as counted rather than estimated."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Count"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/smn/DataQualityAssessment",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -1636,13 +1676,8 @@
   {
     "@id": "https://w3id.org/smn/EnumerationMethod",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
-    ],
-    "http://purl.obolibrary.org/obo/IAO_0000115": [
-      {
-        "@language": "en",
-        "@value": "A method used to enumerate or count salmon in the field"
-      }
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "http://www.w3.org/ns/sosa/Procedure"
     ],
     "http://purl.obolibrary.org/obo/IAO_0000119": [
       {
@@ -1660,15 +1695,26 @@
         "@id": "https://w3id.org/smn"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "A method used to enumerate or count salmon in the field."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/MethodScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
         "@value": "Enumeration method"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
       {
-        "@id": "http://www.w3.org/ns/sosa/Procedure"
+        "@id": "https://w3id.org/smn/MethodScheme"
       }
     ]
   },
@@ -1931,22 +1977,28 @@
   {
     "@id": "https://w3id.org/smn/FishForkLengthMeasurementMethod",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "http://www.w3.org/ns/sosa/Procedure"
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2004/02/skos/core#broader": [
+      {
+        "@id": "https://w3id.org/smn/FishLengthMeasurementMethod"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/MethodScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
         "@value": "Fish fork-length measurement method"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/smn/FishLengthMeasurementMethod"
       }
     ]
   },
@@ -1975,22 +2027,28 @@
   {
     "@id": "https://w3id.org/smn/FishLengthMeasurementMethod",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "http://www.w3.org/ns/sosa/Procedure"
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/MethodScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
         "@value": "Fish length measurement method"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
       {
-        "@id": "http://www.w3.org/ns/sosa/Procedure"
+        "@id": "https://w3id.org/smn/MethodScheme"
       }
     ]
   },
@@ -1998,6 +2056,12 @@
     "@id": "https://w3id.org/smn/FishLengthMeasurementType",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#comment": [
+      {
+        "@language": "en",
+        "@value": "The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class."
+      }
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
@@ -2102,66 +2166,84 @@
   {
     "@id": "https://w3id.org/smn/ForkLengthMeasurementFieldMethod",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "http://www.w3.org/ns/sosa/Procedure"
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2004/02/skos/core#broader": [
+      {
+        "@id": "https://w3id.org/smn/ForkLengthMeasurementMethod"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/MethodScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
         "@value": "Fork-length field method"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/smn/ForkLengthMeasurementMethod"
       }
     ]
   },
   {
     "@id": "https://w3id.org/smn/ForkLengthMeasurementLabMethod",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "http://www.w3.org/ns/sosa/Procedure"
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2004/02/skos/core#broader": [
+      {
+        "@id": "https://w3id.org/smn/ForkLengthMeasurementMethod"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/MethodScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
         "@value": "Fork-length lab method"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/smn/ForkLengthMeasurementMethod"
       }
     ]
   },
   {
     "@id": "https://w3id.org/smn/ForkLengthMeasurementMethod",
     "@type": [
-      "http://www.w3.org/2002/07/owl#Class"
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "http://www.w3.org/ns/sosa/Procedure"
     ],
     "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
       {
         "@id": "https://w3id.org/smn"
       }
     ],
-    "http://www.w3.org/2000/01/rdf-schema#label": [
+    "http://www.w3.org/2004/02/skos/core#broader": [
+      {
+        "@id": "https://w3id.org/smn/FishForkLengthMeasurementMethod"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/MethodScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
       {
         "@language": "en",
         "@value": "Fork-length measurement method"
-      }
-    ],
-    "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
-      {
-        "@id": "https://w3id.org/smn/FishForkLengthMeasurementMethod"
       }
     ]
   },
@@ -2663,6 +2745,84 @@
     ]
   },
   {
+    "@id": "https://w3id.org/smn/MaximumStatisticalModifier",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "https://w3id.org/iadopt/ont/StatisticalModifier"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "http://vocabulary.odm2.org/aggregationstatistic/maximum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The reported value is the maximum of the summarized observations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Maximum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/smn/MeanStatisticalModifier",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "https://w3id.org/iadopt/ont/StatisticalModifier"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "http://vocabulary.odm2.org/aggregationstatistic/average"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The reported value is the arithmetic mean of the summarized observations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Mean"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/smn/Measurement",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -2781,6 +2941,45 @@
     ]
   },
   {
+    "@id": "https://w3id.org/smn/MedianStatisticalModifier",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "https://w3id.org/iadopt/ont/StatisticalModifier"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "http://vocabulary.odm2.org/aggregationstatistic/median"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The reported value is the median of the summarized observations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Median"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/smn/MethodDocumentation",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -2805,6 +3004,37 @@
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
         "@id": "http://purl.obolibrary.org/obo/IAO_0000030"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/smn/MethodScheme",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11)."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#hasTopConcept": [
+      {
+        "@id": "https://w3id.org/smn/EnumerationMethod"
+      },
+      {
+        "@id": "https://w3id.org/smn/FishLengthMeasurementMethod"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Method scheme"
       }
     ]
   },
@@ -2844,6 +3074,45 @@
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
         "@id": "http://purl.obolibrary.org/obo/IAO_0000030"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/smn/MinimumStatisticalModifier",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "https://w3id.org/iadopt/ont/StatisticalModifier"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "http://vocabulary.odm2.org/aggregationstatistic/minimum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The reported value is the minimum of the summarized observations."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Minimum"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
       }
     ]
   },
@@ -3120,6 +3389,40 @@
       {
         "@language": "en",
         "@value": "Ocean phase"
+      }
+    ]
+  },
+  {
+    "@id": "https://w3id.org/smn/PeakStatisticalModifier",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "https://w3id.org/iadopt/ont/StatisticalModifier"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Peak"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
       }
     ]
   },
@@ -3731,6 +4034,52 @@
     ]
   },
   {
+    "@id": "https://w3id.org/smn/StatisticalModifierScheme",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#ConceptScheme"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#hasTopConcept": [
+      {
+        "@id": "https://w3id.org/smn/CountStatisticalModifier"
+      },
+      {
+        "@id": "https://w3id.org/smn/MaximumStatisticalModifier"
+      },
+      {
+        "@id": "https://w3id.org/smn/MeanStatisticalModifier"
+      },
+      {
+        "@id": "https://w3id.org/smn/MedianStatisticalModifier"
+      },
+      {
+        "@id": "https://w3id.org/smn/MinimumStatisticalModifier"
+      },
+      {
+        "@id": "https://w3id.org/smn/PeakStatisticalModifier"
+      },
+      {
+        "@id": "https://w3id.org/smn/TotalStatisticalModifier"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Statistical modifier scheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/smn/Stock",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -4101,6 +4450,45 @@
     ]
   },
   {
+    "@id": "https://w3id.org/smn/TotalStatisticalModifier",
+    "@type": [
+      "http://www.w3.org/2004/02/skos/core#Concept",
+      "https://w3id.org/iadopt/ont/StatisticalModifier"
+    ],
+    "http://www.w3.org/2000/01/rdf-schema#isDefinedBy": [
+      {
+        "@id": "https://w3id.org/smn"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "http://vocabulary.odm2.org/aggregationstatistic/cumulative"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@language": "en",
+        "@value": "The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@language": "en",
+        "@value": "Total"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#topConceptOf": [
+      {
+        "@id": "https://w3id.org/smn/StatisticalModifierScheme"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/smn/YearBasis",
     "@type": [
       "http://www.w3.org/2004/02/skos/core#Concept"
@@ -4245,7 +4633,7 @@
     ],
     "http://www.w3.org/2000/01/rdf-schema#range": [
       {
-        "@id": "https://w3id.org/smn/EnumerationMethod"
+        "@id": "http://www.w3.org/ns/sosa/Procedure"
       }
     ]
   },

--- a/docs/smn.owl
+++ b/docs/smn.owl
@@ -563,7 +563,7 @@
                 <owl:someValuesFrom rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:comment xml:lang="en">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07&apos;s smn:MethodScheme (e.g. smn:EnumerationMethod).</rdfs:comment>
+        <rdfs:comment xml:lang="en">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Aggregated measurement</rdfs:label>
     </owl:Class>

--- a/docs/smn.owl
+++ b/docs/smn.owl
@@ -144,6 +144,12 @@
 
 
 
+    <!-- http://www.w3.org/2004/02/skos/core#topConceptOf -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2004/02/skos/core#topConceptOf"/>
+
+
+
     <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -218,7 +224,7 @@
 
     <owl:ObjectProperty rdf:about="https://w3id.org/smn/basedOn">
         <rdfs:domain rdf:resource="https://w3id.org/smn/AggregatedMeasurement"/>
-        <rdfs:range rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
+        <rdfs:range rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">based on</rdfs:label>
     </owl:ObjectProperty>
@@ -554,9 +560,10 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="https://w3id.org/smn/basedOn"/>
-                <owl:someValuesFrom rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07&apos;s smn:MethodScheme (e.g. smn:EnumerationMethod).</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Aggregated measurement</rdfs:label>
     </owl:Class>
@@ -634,19 +641,6 @@
 
 
 
-    <!-- https://w3id.org/smn/EnumerationMethod -->
-
-    <owl:Class rdf:about="https://w3id.org/smn/EnumerationMethod">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
-        <ns1:IAO_0000115 xml:lang="en">A method used to enumerate or count salmon in the field</ns1:IAO_0000115>
-        <ns1:IAO_0000119 xml:lang="en">GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod.</ns1:IAO_0000119>
-        <dcterms:source rdf:resource="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
-        <rdfs:label xml:lang="en">Enumeration method</rdfs:label>
-    </owl:Class>
-
-
-
     <!-- https://w3id.org/smn/Escapement -->
 
     <owl:Class rdf:about="https://w3id.org/smn/Escapement">
@@ -712,32 +706,12 @@
 
 
 
-    <!-- https://w3id.org/smn/FishForkLengthMeasurementMethod -->
-
-    <owl:Class rdf:about="https://w3id.org/smn/FishForkLengthMeasurementMethod">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/smn/FishLengthMeasurementMethod"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
-        <rdfs:label xml:lang="en">Fish fork-length measurement method</rdfs:label>
-    </owl:Class>
-
-
-
     <!-- https://w3id.org/smn/FishLength -->
 
     <owl:Class rdf:about="https://w3id.org/smn/FishLength">
         <rdfs:subClassOf rdf:resource="https://w3id.org/smn/MorphologicalCharacteristic"/>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Fish length</rdfs:label>
-    </owl:Class>
-
-
-
-    <!-- https://w3id.org/smn/FishLengthMeasurementMethod -->
-
-    <owl:Class rdf:about="https://w3id.org/smn/FishLengthMeasurementMethod">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
-        <rdfs:label xml:lang="en">Fish length measurement method</rdfs:label>
     </owl:Class>
 
 
@@ -755,9 +729,10 @@
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://www.w3.org/ns/sosa/usedProcedure"/>
-                <owl:someValuesFrom rdf:resource="https://w3id.org/smn/FishLengthMeasurementMethod"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
             </owl:Restriction>
         </rdfs:subClassOf>
+        <rdfs:comment xml:lang="en">The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07&apos;s smn:MethodScheme, and someValuesFrom needs a class.</rdfs:comment>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Fish length measurement type</rdfs:label>
     </owl:Class>
@@ -796,36 +771,6 @@
         </rdfs:subClassOf>
         <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
         <rdfs:label xml:lang="en">Fork-length measurement</rdfs:label>
-    </owl:Class>
-
-
-
-    <!-- https://w3id.org/smn/ForkLengthMeasurementFieldMethod -->
-
-    <owl:Class rdf:about="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/smn/ForkLengthMeasurementMethod"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
-        <rdfs:label xml:lang="en">Fork-length field method</rdfs:label>
-    </owl:Class>
-
-
-
-    <!-- https://w3id.org/smn/ForkLengthMeasurementLabMethod -->
-
-    <owl:Class rdf:about="https://w3id.org/smn/ForkLengthMeasurementLabMethod">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/smn/ForkLengthMeasurementMethod"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
-        <rdfs:label xml:lang="en">Fork-length lab method</rdfs:label>
-    </owl:Class>
-
-
-
-    <!-- https://w3id.org/smn/ForkLengthMeasurementMethod -->
-
-    <owl:Class rdf:about="https://w3id.org/smn/ForkLengthMeasurementMethod">
-        <rdfs:subClassOf rdf:resource="https://w3id.org/smn/FishForkLengthMeasurementMethod"/>
-        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
-        <rdfs:label xml:lang="en">Fork-length measurement method</rdfs:label>
     </owl:Class>
 
 
@@ -1661,6 +1606,36 @@
 
 
 
+    <!-- https://w3id.org/smn/CountStatisticalModifier -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/CountStatisticalModifier">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="https://w3id.org/iadopt/ont/StatisticalModifier"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:definition xml:lang="en">The reported value is the number of summarized observations or individuals, as counted rather than estimated.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+        <skos:prefLabel xml:lang="en">Count</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/EnumerationMethod -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/EnumerationMethod">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
+        <ns1:IAO_0000119 xml:lang="en">GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod.</ns1:IAO_0000119>
+        <dcterms:source rdf:resource="https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:definition xml:lang="en">A method used to enumerate or count salmon in the field.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/MethodScheme"/>
+        <skos:prefLabel xml:lang="en">Enumeration method</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/MethodScheme"/>
+    </owl:NamedIndividual>
+
+
+
     <!-- https://w3id.org/smn/EuropeanAgeNotation -->
 
     <owl:NamedIndividual rdf:about="https://w3id.org/smn/EuropeanAgeNotation">
@@ -1675,6 +1650,71 @@
         <skos:notation>European</skos:notation>
         <skos:prefLabel xml:lang="en">European age notation</skos:prefLabel>
         <skos:scopeNote xml:lang="en">For example, 1.2 represents freshwater-age value 1 and ocean-age value 2 when the source declares European notation.</skos:scopeNote>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/FishForkLengthMeasurementMethod -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/FishForkLengthMeasurementMethod">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:broader rdf:resource="https://w3id.org/smn/FishLengthMeasurementMethod"/>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/MethodScheme"/>
+        <skos:prefLabel xml:lang="en">Fish fork-length measurement method</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/FishLengthMeasurementMethod -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/FishLengthMeasurementMethod">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/MethodScheme"/>
+        <skos:prefLabel xml:lang="en">Fish length measurement method</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/MethodScheme"/>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/ForkLengthMeasurementFieldMethod -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/ForkLengthMeasurementFieldMethod">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:broader rdf:resource="https://w3id.org/smn/ForkLengthMeasurementMethod"/>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/MethodScheme"/>
+        <skos:prefLabel xml:lang="en">Fork-length field method</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/ForkLengthMeasurementLabMethod -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/ForkLengthMeasurementLabMethod">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:broader rdf:resource="https://w3id.org/smn/ForkLengthMeasurementMethod"/>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/MethodScheme"/>
+        <skos:prefLabel xml:lang="en">Fork-length lab method</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/ForkLengthMeasurementMethod -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/ForkLengthMeasurementMethod">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="http://www.w3.org/ns/sosa/Procedure"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:broader rdf:resource="https://w3id.org/smn/FishForkLengthMeasurementMethod"/>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/MethodScheme"/>
+        <skos:prefLabel xml:lang="en">Fork-length measurement method</skos:prefLabel>
     </owl:NamedIndividual>
 
 
@@ -1787,6 +1827,36 @@
 
 
 
+    <!-- https://w3id.org/smn/MaximumStatisticalModifier -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/MaximumStatisticalModifier">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="https://w3id.org/iadopt/ont/StatisticalModifier"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:closeMatch rdf:resource="http://vocabulary.odm2.org/aggregationstatistic/maximum"/>
+        <skos:definition xml:lang="en">The reported value is the maximum of the summarized observations.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+        <skos:prefLabel xml:lang="en">Maximum</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/MeanStatisticalModifier -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/MeanStatisticalModifier">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="https://w3id.org/iadopt/ont/StatisticalModifier"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:closeMatch rdf:resource="http://vocabulary.odm2.org/aggregationstatistic/average"/>
+        <skos:definition xml:lang="en">The reported value is the arithmetic mean of the summarized observations.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+        <skos:prefLabel xml:lang="en">Mean</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+    </owl:NamedIndividual>
+
+
+
     <!-- https://w3id.org/smn/MeasurementContext -->
 
     <owl:NamedIndividual rdf:about="https://w3id.org/smn/MeasurementContext">
@@ -1811,6 +1881,49 @@
         <skos:definition xml:lang="en">Controlled vocabulary for compositional measurement context qualifiers (for example, catch context, run context).</skos:definition>
         <skos:hasTopConcept rdf:resource="https://w3id.org/smn/MeasurementContext"/>
         <skos:prefLabel xml:lang="en">Measurement context scheme</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/MedianStatisticalModifier -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/MedianStatisticalModifier">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="https://w3id.org/iadopt/ont/StatisticalModifier"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:closeMatch rdf:resource="http://vocabulary.odm2.org/aggregationstatistic/median"/>
+        <skos:definition xml:lang="en">The reported value is the median of the summarized observations.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+        <skos:prefLabel xml:lang="en">Median</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/MethodScheme -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/MethodScheme">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:definition xml:lang="en">Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11).</skos:definition>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/EnumerationMethod"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/FishLengthMeasurementMethod"/>
+        <skos:prefLabel xml:lang="en">Method scheme</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/MinimumStatisticalModifier -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/MinimumStatisticalModifier">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="https://w3id.org/iadopt/ont/StatisticalModifier"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:closeMatch rdf:resource="http://vocabulary.odm2.org/aggregationstatistic/minimum"/>
+        <skos:definition xml:lang="en">The reported value is the minimum of the summarized observations.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+        <skos:prefLabel xml:lang="en">Minimum</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
     </owl:NamedIndividual>
 
 
@@ -1859,6 +1972,20 @@
         <skos:definition xml:lang="en">Phase of the salmon life cycle or assessment period occurring in the marine environment.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/LifePhaseScheme"/>
         <skos:prefLabel xml:lang="en">Ocean phase</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/PeakStatisticalModifier -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/PeakStatisticalModifier">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="https://w3id.org/iadopt/ont/StatisticalModifier"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:definition xml:lang="en">The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+        <skos:prefLabel xml:lang="en">Peak</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
     </owl:NamedIndividual>
 
 
@@ -1938,6 +2065,24 @@
 
 
 
+    <!-- https://w3id.org/smn/StatisticalModifierScheme -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/StatisticalModifierScheme">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#ConceptScheme"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:definition xml:lang="en">Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring.</skos:definition>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/CountStatisticalModifier"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/MaximumStatisticalModifier"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/MeanStatisticalModifier"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/MedianStatisticalModifier"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/MinimumStatisticalModifier"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/PeakStatisticalModifier"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/smn/TotalStatisticalModifier"/>
+        <skos:prefLabel xml:lang="en">Statistical modifier scheme</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
     <!-- https://w3id.org/smn/SurvivalOrMortalityContext -->
 
     <owl:NamedIndividual rdf:about="https://w3id.org/smn/SurvivalOrMortalityContext">
@@ -1980,6 +2125,21 @@
         <skos:definition xml:lang="en">Age dimension whose value represents total salmon age under the declared age convention.</skos:definition>
         <skos:inScheme rdf:resource="https://w3id.org/smn/AgeDimensionScheme"/>
         <skos:prefLabel xml:lang="en">Total-age dimension</skos:prefLabel>
+    </owl:NamedIndividual>
+
+
+
+    <!-- https://w3id.org/smn/TotalStatisticalModifier -->
+
+    <owl:NamedIndividual rdf:about="https://w3id.org/smn/TotalStatisticalModifier">
+        <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+        <rdf:type rdf:resource="https://w3id.org/iadopt/ont/StatisticalModifier"/>
+        <rdfs:isDefinedBy rdf:resource="https://w3id.org/smn"/>
+        <skos:closeMatch rdf:resource="http://vocabulary.odm2.org/aggregationstatistic/cumulative"/>
+        <skos:definition xml:lang="en">The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement.</skos:definition>
+        <skos:inScheme rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
+        <skos:prefLabel xml:lang="en">Total</skos:prefLabel>
+        <skos:topConceptOf rdf:resource="https://w3id.org/smn/StatisticalModifierScheme"/>
     </owl:NamedIndividual>
 
 

--- a/docs/smn.ttl
+++ b/docs/smn.ttl
@@ -104,6 +104,10 @@ skos:prefLabel rdf:type owl:AnnotationProperty .
 skos:scopeNote rdf:type owl:AnnotationProperty .
 
 
+###  http://www.w3.org/2004/02/skos/core#topConceptOf
+skos:topConceptOf rdf:type owl:AnnotationProperty .
+
+
 #################################################################
 #    Datatypes
 #################################################################
@@ -147,7 +151,7 @@ sosa:usedProcedure rdf:type owl:ObjectProperty .
 ###  https://w3id.org/smn/basedOn
 <https://w3id.org/smn/basedOn> rdf:type owl:ObjectProperty ;
                                rdfs:domain <https://w3id.org/smn/AggregatedMeasurement> ;
-                               rdfs:range <https://w3id.org/smn/EnumerationMethod> ;
+                               rdfs:range sosa:Procedure ;
                                rdfs:isDefinedBy <https://w3id.org/smn> ;
                                rdfs:label "based on"@en .
 
@@ -374,8 +378,9 @@ sosa:Sampling rdf:type owl:Class ;
                                              rdfs:subClassOf <https://w3id.org/smn/Measurement> ,
                                                              [ rdf:type owl:Restriction ;
                                                                owl:onProperty <https://w3id.org/smn/basedOn> ;
-                                                               owl:someValuesFrom <https://w3id.org/smn/EnumerationMethod>
+                                                               owl:someValuesFrom sosa:Procedure
                                                              ] ;
+                                             rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en ;
                                              rdfs:isDefinedBy <https://w3id.org/smn> ;
                                              rdfs:label "Aggregated measurement"@en .
 
@@ -433,16 +438,6 @@ sosa:Sampling rdf:type owl:Class ;
                               rdfs:label "Entity"@en .
 
 
-###  https://w3id.org/smn/EnumerationMethod
-<https://w3id.org/smn/EnumerationMethod> rdf:type owl:Class ;
-                                         rdfs:subClassOf sosa:Procedure ;
-                                         ns1:IAO_0000115 "A method used to enumerate or count salmon in the field"@en ;
-                                         ns1:IAO_0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en ;
-                                         dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> ;
-                                         rdfs:isDefinedBy <https://w3id.org/smn> ;
-                                         rdfs:label "Enumeration method"@en .
-
-
 ###  https://w3id.org/smn/Escapement
 <https://w3id.org/smn/Escapement> rdf:type owl:Class ;
                                   rdfs:subClassOf ns1:BFO_0000015 ;
@@ -493,25 +488,11 @@ sosa:Sampling rdf:type owl:Class ;
                                         rdfs:label "Exploitation rate"@en .
 
 
-###  https://w3id.org/smn/FishForkLengthMeasurementMethod
-<https://w3id.org/smn/FishForkLengthMeasurementMethod> rdf:type owl:Class ;
-                                                       rdfs:subClassOf <https://w3id.org/smn/FishLengthMeasurementMethod> ;
-                                                       rdfs:isDefinedBy <https://w3id.org/smn> ;
-                                                       rdfs:label "Fish fork-length measurement method"@en .
-
-
 ###  https://w3id.org/smn/FishLength
 <https://w3id.org/smn/FishLength> rdf:type owl:Class ;
                                   rdfs:subClassOf <https://w3id.org/smn/MorphologicalCharacteristic> ;
                                   rdfs:isDefinedBy <https://w3id.org/smn> ;
                                   rdfs:label "Fish length"@en .
-
-
-###  https://w3id.org/smn/FishLengthMeasurementMethod
-<https://w3id.org/smn/FishLengthMeasurementMethod> rdf:type owl:Class ;
-                                                   rdfs:subClassOf sosa:Procedure ;
-                                                   rdfs:isDefinedBy <https://w3id.org/smn> ;
-                                                   rdfs:label "Fish length measurement method"@en .
 
 
 ###  https://w3id.org/smn/FishLengthMeasurementType
@@ -523,8 +504,9 @@ sosa:Sampling rdf:type owl:Class ;
                                                                  ] ,
                                                                  [ rdf:type owl:Restriction ;
                                                                    owl:onProperty sosa:usedProcedure ;
-                                                                   owl:someValuesFrom <https://w3id.org/smn/FishLengthMeasurementMethod>
+                                                                   owl:someValuesFrom sosa:Procedure
                                                                  ] ;
+                                                 rdfs:comment "The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class."@en ;
                                                  rdfs:isDefinedBy <https://w3id.org/smn> ;
                                                  rdfs:label "Fish length measurement type"@en .
 
@@ -552,27 +534,6 @@ sosa:Sampling rdf:type owl:Class ;
                                                              ] ;
                                              rdfs:isDefinedBy <https://w3id.org/smn> ;
                                              rdfs:label "Fork-length measurement"@en .
-
-
-###  https://w3id.org/smn/ForkLengthMeasurementFieldMethod
-<https://w3id.org/smn/ForkLengthMeasurementFieldMethod> rdf:type owl:Class ;
-                                                        rdfs:subClassOf <https://w3id.org/smn/ForkLengthMeasurementMethod> ;
-                                                        rdfs:isDefinedBy <https://w3id.org/smn> ;
-                                                        rdfs:label "Fork-length field method"@en .
-
-
-###  https://w3id.org/smn/ForkLengthMeasurementLabMethod
-<https://w3id.org/smn/ForkLengthMeasurementLabMethod> rdf:type owl:Class ;
-                                                      rdfs:subClassOf <https://w3id.org/smn/ForkLengthMeasurementMethod> ;
-                                                      rdfs:isDefinedBy <https://w3id.org/smn> ;
-                                                      rdfs:label "Fork-length lab method"@en .
-
-
-###  https://w3id.org/smn/ForkLengthMeasurementMethod
-<https://w3id.org/smn/ForkLengthMeasurementMethod> rdf:type owl:Class ;
-                                                   rdfs:subClassOf <https://w3id.org/smn/FishForkLengthMeasurementMethod> ;
-                                                   rdfs:isDefinedBy <https://w3id.org/smn> ;
-                                                   rdfs:label "Fork-length measurement method"@en .
 
 
 ###  https://w3id.org/smn/GeographicFeature
@@ -1209,6 +1170,30 @@ sosa:Sampling rdf:type owl:Class ;
                                       skos:scopeNote "Use smn:catchYear for the xsd:gYear coordinate. A catch year is not interchangeable with the return year of the fish."@en .
 
 
+###  https://w3id.org/smn/CountStatisticalModifier
+<https://w3id.org/smn/CountStatisticalModifier> rdf:type owl:NamedIndividual ,
+                                                         skos:Concept ,
+                                                         <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+                                                rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                skos:definition "The reported value is the number of summarized observations or individuals, as counted rather than estimated."@en ;
+                                                skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+                                                skos:prefLabel "Count"@en ;
+                                                skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+
+###  https://w3id.org/smn/EnumerationMethod
+<https://w3id.org/smn/EnumerationMethod> rdf:type owl:NamedIndividual ,
+                                                  skos:Concept ,
+                                                  sosa:Procedure ;
+                                         ns1:IAO_0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en ;
+                                         dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> ;
+                                         rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                         skos:definition "A method used to enumerate or count salmon in the field."@en ;
+                                         skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+                                         skos:prefLabel "Enumeration method"@en ;
+                                         skos:topConceptOf <https://w3id.org/smn/MethodScheme> .
+
+
 ###  https://w3id.org/smn/EuropeanAgeNotation
 <https://w3id.org/smn/EuropeanAgeNotation> rdf:type owl:NamedIndividual ,
                                                     skos:Concept ;
@@ -1222,6 +1207,56 @@ sosa:Sampling rdf:type owl:Class ;
                                            skos:notation "European" ;
                                            skos:prefLabel "European age notation"@en ;
                                            skos:scopeNote "For example, 1.2 represents freshwater-age value 1 and ocean-age value 2 when the source declares European notation."@en .
+
+
+###  https://w3id.org/smn/FishForkLengthMeasurementMethod
+<https://w3id.org/smn/FishForkLengthMeasurementMethod> rdf:type owl:NamedIndividual ,
+                                                                skos:Concept ,
+                                                                sosa:Procedure ;
+                                                       rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                       skos:broader <https://w3id.org/smn/FishLengthMeasurementMethod> ;
+                                                       skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+                                                       skos:prefLabel "Fish fork-length measurement method"@en .
+
+
+###  https://w3id.org/smn/FishLengthMeasurementMethod
+<https://w3id.org/smn/FishLengthMeasurementMethod> rdf:type owl:NamedIndividual ,
+                                                            skos:Concept ,
+                                                            sosa:Procedure ;
+                                                   rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                   skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+                                                   skos:prefLabel "Fish length measurement method"@en ;
+                                                   skos:topConceptOf <https://w3id.org/smn/MethodScheme> .
+
+
+###  https://w3id.org/smn/ForkLengthMeasurementFieldMethod
+<https://w3id.org/smn/ForkLengthMeasurementFieldMethod> rdf:type owl:NamedIndividual ,
+                                                                 skos:Concept ,
+                                                                 sosa:Procedure ;
+                                                        rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                        skos:broader <https://w3id.org/smn/ForkLengthMeasurementMethod> ;
+                                                        skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+                                                        skos:prefLabel "Fork-length field method"@en .
+
+
+###  https://w3id.org/smn/ForkLengthMeasurementLabMethod
+<https://w3id.org/smn/ForkLengthMeasurementLabMethod> rdf:type owl:NamedIndividual ,
+                                                               skos:Concept ,
+                                                               sosa:Procedure ;
+                                                      rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                      skos:broader <https://w3id.org/smn/ForkLengthMeasurementMethod> ;
+                                                      skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+                                                      skos:prefLabel "Fork-length lab method"@en .
+
+
+###  https://w3id.org/smn/ForkLengthMeasurementMethod
+<https://w3id.org/smn/ForkLengthMeasurementMethod> rdf:type owl:NamedIndividual ,
+                                                            skos:Concept ,
+                                                            sosa:Procedure ;
+                                                   rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                   skos:broader <https://w3id.org/smn/FishForkLengthMeasurementMethod> ;
+                                                   skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+                                                   skos:prefLabel "Fork-length measurement method"@en .
 
 
 ###  https://w3id.org/smn/FreshwaterAgeDimension
@@ -1311,6 +1346,30 @@ sosa:Sampling rdf:type owl:Class ;
                                      skos:prefLabel "Mainstem phase"@en .
 
 
+###  https://w3id.org/smn/MaximumStatisticalModifier
+<https://w3id.org/smn/MaximumStatisticalModifier> rdf:type owl:NamedIndividual ,
+                                                           skos:Concept ,
+                                                           <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+                                                  rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                  skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/maximum> ;
+                                                  skos:definition "The reported value is the maximum of the summarized observations."@en ;
+                                                  skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+                                                  skos:prefLabel "Maximum"@en ;
+                                                  skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+
+###  https://w3id.org/smn/MeanStatisticalModifier
+<https://w3id.org/smn/MeanStatisticalModifier> rdf:type owl:NamedIndividual ,
+                                                        skos:Concept ,
+                                                        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+                                               rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                               skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/average> ;
+                                               skos:definition "The reported value is the arithmetic mean of the summarized observations."@en ;
+                                               skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+                                               skos:prefLabel "Mean"@en ;
+                                               skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+
 ###  https://w3id.org/smn/MeasurementContext
 <https://w3id.org/smn/MeasurementContext> rdf:type owl:NamedIndividual ,
                                                    skos:Concept ;
@@ -1331,6 +1390,40 @@ sosa:Sampling rdf:type owl:Class ;
                                                 skos:definition "Controlled vocabulary for compositional measurement context qualifiers (for example, catch context, run context)."@en ;
                                                 skos:hasTopConcept <https://w3id.org/smn/MeasurementContext> ;
                                                 skos:prefLabel "Measurement context scheme"@en .
+
+
+###  https://w3id.org/smn/MedianStatisticalModifier
+<https://w3id.org/smn/MedianStatisticalModifier> rdf:type owl:NamedIndividual ,
+                                                          skos:Concept ,
+                                                          <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+                                                 rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                 skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/median> ;
+                                                 skos:definition "The reported value is the median of the summarized observations."@en ;
+                                                 skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+                                                 skos:prefLabel "Median"@en ;
+                                                 skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+
+###  https://w3id.org/smn/MethodScheme
+<https://w3id.org/smn/MethodScheme> rdf:type owl:NamedIndividual ,
+                                             skos:ConceptScheme ;
+                                    rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                    skos:definition "Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11)."@en ;
+                                    skos:hasTopConcept <https://w3id.org/smn/EnumerationMethod> ,
+                                                       <https://w3id.org/smn/FishLengthMeasurementMethod> ;
+                                    skos:prefLabel "Method scheme"@en .
+
+
+###  https://w3id.org/smn/MinimumStatisticalModifier
+<https://w3id.org/smn/MinimumStatisticalModifier> rdf:type owl:NamedIndividual ,
+                                                           skos:Concept ,
+                                                           <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+                                                  rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                  skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/minimum> ;
+                                                  skos:definition "The reported value is the minimum of the summarized observations."@en ;
+                                                  skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+                                                  skos:prefLabel "Minimum"@en ;
+                                                  skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
 
 
 ###  https://w3id.org/smn/NaturalOrigin
@@ -1370,6 +1463,17 @@ sosa:Sampling rdf:type owl:Class ;
                                   skos:definition "Phase of the salmon life cycle or assessment period occurring in the marine environment."@en ;
                                   skos:inScheme <https://w3id.org/smn/LifePhaseScheme> ;
                                   skos:prefLabel "Ocean phase"@en .
+
+
+###  https://w3id.org/smn/PeakStatisticalModifier
+<https://w3id.org/smn/PeakStatisticalModifier> rdf:type owl:NamedIndividual ,
+                                                        skos:Concept ,
+                                                        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+                                               rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                               skos:definition "The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey."@en ;
+                                               skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+                                               skos:prefLabel "Peak"@en ;
+                                               skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
 
 
 ###  https://w3id.org/smn/ReturnYearBasis
@@ -1432,6 +1536,21 @@ sosa:Sampling rdf:type owl:Class ;
                                            skos:prefLabel "Spawner stage context"@en .
 
 
+###  https://w3id.org/smn/StatisticalModifierScheme
+<https://w3id.org/smn/StatisticalModifierScheme> rdf:type owl:NamedIndividual ,
+                                                          skos:ConceptScheme ;
+                                                 rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                 skos:definition "Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring."@en ;
+                                                 skos:hasTopConcept <https://w3id.org/smn/CountStatisticalModifier> ,
+                                                                    <https://w3id.org/smn/MaximumStatisticalModifier> ,
+                                                                    <https://w3id.org/smn/MeanStatisticalModifier> ,
+                                                                    <https://w3id.org/smn/MedianStatisticalModifier> ,
+                                                                    <https://w3id.org/smn/MinimumStatisticalModifier> ,
+                                                                    <https://w3id.org/smn/PeakStatisticalModifier> ,
+                                                                    <https://w3id.org/smn/TotalStatisticalModifier> ;
+                                                 skos:prefLabel "Statistical modifier scheme"@en .
+
+
 ###  https://w3id.org/smn/SurvivalOrMortalityContext
 <https://w3id.org/smn/SurvivalOrMortalityContext> rdf:type owl:NamedIndividual ,
                                                            skos:Concept ;
@@ -1467,6 +1586,18 @@ sosa:Sampling rdf:type owl:Class ;
                                          skos:definition "Age dimension whose value represents total salmon age under the declared age convention."@en ;
                                          skos:inScheme <https://w3id.org/smn/AgeDimensionScheme> ;
                                          skos:prefLabel "Total-age dimension"@en .
+
+
+###  https://w3id.org/smn/TotalStatisticalModifier
+<https://w3id.org/smn/TotalStatisticalModifier> rdf:type owl:NamedIndividual ,
+                                                         skos:Concept ,
+                                                         <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+                                                rdfs:isDefinedBy <https://w3id.org/smn> ;
+                                                skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/cumulative> ;
+                                                skos:definition "The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement."@en ;
+                                                skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+                                                skos:prefLabel "Total"@en ;
+                                                skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
 
 
 ###  https://w3id.org/smn/YearBasis

--- a/docs/smn.ttl
+++ b/docs/smn.ttl
@@ -380,7 +380,7 @@ sosa:Sampling rdf:type owl:Class ;
                                                                owl:onProperty <https://w3id.org/smn/basedOn> ;
                                                                owl:someValuesFrom sosa:Procedure
                                                              ] ;
-                                             rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en ;
+                                             rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals."@en ;
                                              rdfs:isDefinedBy <https://w3id.org/smn> ;
                                              rdfs:label "Aggregated measurement"@en .
 

--- a/knowledge/data/cross-vocabulary-alignment-state.md
+++ b/knowledge/data/cross-vocabulary-alignment-state.md
@@ -22,10 +22,13 @@ Any earlier claim that the smn/gcdfo boundary is "prose-only" is stale.
 
 ## Defects in the merged closure
 
-- **Live pun:** `smn:EnumerationMethod` is `owl:Class ⊑ sosa:Procedure` in smn
-  (`modules/02:129`) and `skos:Concept` in gcdfo (`dfo-salmon.ttl:1024`).
-  Because gcdfo imports smn, every reasoner over the closure sees one IRI
-  typed both ways — which both repos' conventions forbid.
+- ~~Live pun~~ **Resolved 2026-08-13 (step 2):** smn migrated its six method
+  OWL classes to SKOS concepts in `smn:MethodScheme` (module 07), each
+  instance-typed `sosa:Procedure`, IRIs unchanged — so `smn:EnumerationMethod`
+  is now `skos:Concept` on both sides and the merged closure has zero
+  dual-typed IRIs (verified against the flat build). PSC's wrong-kind
+  objection (`sdo-alignment-gap.md`) no longer applies; updating their doc
+  and drafting psc→smn SSSOM rows is step 4.
 - **Minted foreign term:** `smn:FisheriesReferencePointLower` is declared
   only in `dfo-salmon.ttl` (~line 1920); smn never declares it.
 - **Unbridged duplication:** the 18-term age/year SKOS family exists twice —

--- a/knowledge/data/owl-skos-conventions-state.md
+++ b/knowledge/data/owl-skos-conventions-state.md
@@ -9,14 +9,19 @@ psc:
   contexts: [smn:context:ontology-alignment-pass-2026]
 ---
 
-Verified 2026-08-12 (main at `3995a17`). Fix plan: step 1 of
+Originally verified 2026-08-12 (main at `3995a17`); inventory refreshed
+2026-08-13 after S9 steps 1/2/5 landed. Fix plan: step 1 of
 `metasalmon/knowledge/plans/2026-08-12-ontology-alignment-pass.md`.
 
 ## What holds
 
-- File-level OWL/SKOS separation is clean: modules 01–05 pure OWL (63
-  classes, 13 properties), module 07 pure SKOS (8 schemes, 36 concepts),
-  bridges 08/09 pure profile-namespace SKOS.
+- File-level OWL/SKOS separation is clean: modules 01–05 pure OWL, module
+  07 pure SKOS (**10 schemes, 49 concepts** as of 2026-08-13 — the original
+  recon counted 8/36 before `smn:MethodScheme` and
+  `smn:StatisticalModifierScheme` landed; six method concepts carry
+  `sosa:Procedure` and seven carry `iadopt:StatisticalModifier` instance
+  typing per the CONVENTIONS §3 instance-typing rule), bridges 08/09 pure
+  profile-namespace SKOS.
 - The dual-representation rule (`CONVENTIONS.md:72`) holds at the
   explicit-typing level: **no IRI in `ontology/modules/` is declared both
   `owl:Class` and `skos:Concept`** (scripted scan).

--- a/knowledge/data/owl-skos-conventions-state.md
+++ b/knowledge/data/owl-skos-conventions-state.md
@@ -40,7 +40,10 @@ Verified 2026-08-12 (main at `3995a17`). Fix plan: step 1 of
 > 02's class-level property assertions are gone, and CONVENTIONS §5b now
 > states the one-strongest-mapping and foreign-subject rules (verified by
 > one-off rdflib checks: 0 violations; CI wiring is the follow-up PR).
-> F8's scheme (`smn:StatisticalModifierScheme`) is S9 step 5.
+> F8's scheme landed 2026-08-13 with steps 2+5: `smn:MethodScheme` (six
+> migrated method concepts, instance-typed `sosa:Procedure`) and
+> `smn:StatisticalModifierScheme` (seven concepts, instance-typed
+> `iadopt:StatisticalModifier`, advisory ODM2 links) both live in module 07.
 
 - **F1 (nuanced)** — the views assert OWL axioms on foreign subjects
   (`iadopt:Variable rdfs:subClassOf iao:0000030, sosa:Property`

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -18,3 +18,7 @@
   fixed; conventions cards updated to reflect the landed state.
 - 2026-08-13 — S9 steps 2+5: methods-as-SKOS migration (smn:MethodScheme) and
   smn:StatisticalModifierScheme landed; cross-repo pun resolved; cards updated.
+- 2026-08-13 — PR 22 review: added ontology/shapes/method-shapes.ttl (the
+  enumeration-method value constraint, SKOS-native via skos:broader*,
+  behaviourally tested with pyshacl) and refreshed the conventions card's
+  module-07 inventory (10 schemes / 49 concepts).

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -16,3 +16,5 @@
   migration.
 - 2026-08-13 — S9 step 1 (alignment semantics): F1-F7 fixed, F8 property-side
   fixed; conventions cards updated to reflect the landed state.
+- 2026-08-13 — S9 steps 2+5: methods-as-SKOS migration (smn:MethodScheme) and
+  smn:StatisticalModifierScheme landed; cross-repo pun resolved; cards updated.

--- a/ontology/modules/02-observation-measurement.ttl
+++ b/ontology/modules/02-observation-measurement.ttl
@@ -101,38 +101,16 @@ smn:Run a owl:Class ;
   rdfs:subClassOf smn:Life-HistoryCharacteristic ;
   rdfs:isDefinedBy <https://w3id.org/smn> .
 
-smn:FishLengthMeasurementMethod a owl:Class ;
-  rdfs:label "Fish length measurement method"@en ;
-  rdfs:subClassOf sosa:Procedure ;
-  rdfs:isDefinedBy <https://w3id.org/smn> .
-
-smn:FishForkLengthMeasurementMethod a owl:Class ;
-  rdfs:label "Fish fork-length measurement method"@en ;
-  rdfs:subClassOf smn:FishLengthMeasurementMethod ;
-  rdfs:isDefinedBy <https://w3id.org/smn> .
-
-smn:ForkLengthMeasurementMethod a owl:Class ;
-  rdfs:label "Fork-length measurement method"@en ;
-  rdfs:subClassOf smn:FishForkLengthMeasurementMethod ;
-  rdfs:isDefinedBy <https://w3id.org/smn> .
-
-smn:ForkLengthMeasurementFieldMethod a owl:Class ;
-  rdfs:label "Fork-length field method"@en ;
-  rdfs:subClassOf smn:ForkLengthMeasurementMethod ;
-  rdfs:isDefinedBy <https://w3id.org/smn> .
-
-smn:ForkLengthMeasurementLabMethod a owl:Class ;
-  rdfs:label "Fork-length lab method"@en ;
-  rdfs:subClassOf smn:ForkLengthMeasurementMethod ;
-  rdfs:isDefinedBy <https://w3id.org/smn> .
-
-smn:EnumerationMethod a owl:Class ;
-  rdfs:label "Enumeration method"@en ;
-  rdfs:subClassOf sosa:Procedure ;
-  iao:0000115 "A method used to enumerate or count salmon in the field"@en ;
-  rdfs:isDefinedBy <https://w3id.org/smn> ;
-  iao:0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en ;
-  dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> .
+# The six method OWL classes that lived here (smn:EnumerationMethod and
+# the fish-length measurement-method family) migrated to SKOS concepts in
+# module 07's smn:MethodScheme on 2026-08-13 (alignment pass step 2,
+# ordered by Brett: methods are pick-list concepts, not class hierarchies).
+# The IRIs are unchanged; each concept is instance-typed sosa:Procedure so
+# sosa:usedProcedure stays type-correct (CONVENTIONS section 3,
+# instance-typing rule). This also resolves the live cross-repo pun:
+# gcdfo already types smn:EnumerationMethod as a skos:Concept, and the
+# PSC vocabulary's stated blocker on mapping to smn was exactly that the
+# method anchor here was an owl:Class.
 
 smn:Measurement a owl:Class ;
   rdfs:label "Measurement"@en ;
@@ -149,13 +127,14 @@ smn:Measurement a owl:Class ;
 
 smn:FishLengthMeasurementType a owl:Class ;
   rdfs:label "Fish length measurement type"@en ;
+  rdfs:comment "The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class."@en ;
   rdfs:subClassOf smn:Measurement ,
     [ a owl:Restriction ;
       owl:onProperty sosa:observedProperty ;
       owl:someValuesFrom smn:FishLength ],
     [ a owl:Restriction ;
       owl:onProperty sosa:usedProcedure ;
-      owl:someValuesFrom smn:FishLengthMeasurementMethod ] ;
+      owl:someValuesFrom sosa:Procedure ] ;
   rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:ForkLengthMeasurement a owl:Class ;
@@ -188,10 +167,11 @@ smn:ModelMeasurement a owl:Class ;
 
 smn:AggregatedMeasurement a owl:Class ;
   rdfs:label "Aggregated measurement"@en ;
+  rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en ;
   rdfs:subClassOf smn:Measurement ,
     [ a owl:Restriction ;
       owl:onProperty smn:basedOn ;
-      owl:someValuesFrom smn:EnumerationMethod ] ;
+      owl:someValuesFrom sosa:Procedure ] ;
   rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:SamplingEvent a owl:Class ;
@@ -294,7 +274,7 @@ smn:hasEventType a owl:ObjectProperty ;
 smn:basedOn a owl:ObjectProperty ;
   rdfs:label "based on"@en ;
   rdfs:domain smn:AggregatedMeasurement ;
-  rdfs:range smn:EnumerationMethod ;
+  rdfs:range sosa:Procedure ;
   rdfs:isDefinedBy <https://w3id.org/smn> .
 
 smn:characteristicFor a owl:ObjectProperty ;

--- a/ontology/modules/02-observation-measurement.ttl
+++ b/ontology/modules/02-observation-measurement.ttl
@@ -167,7 +167,7 @@ smn:ModelMeasurement a owl:Class ;
 
 smn:AggregatedMeasurement a owl:Class ;
   rdfs:label "Aggregated measurement"@en ;
-  rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en ;
+  rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals."@en ;
   rdfs:subClassOf smn:Measurement ,
     [ a owl:Restriction ;
       owl:onProperty smn:basedOn ;

--- a/ontology/modules/07-controlled-vocabularies.ttl
+++ b/ontology/modules/07-controlled-vocabularies.ttl
@@ -1,4 +1,6 @@
 @prefix smn: <https://w3id.org/smn/> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix iadopt: <https://w3id.org/iadopt/ont/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -426,3 +428,136 @@ smn:AgeClassValue7 a skos:Concept ;
   rdfs:isDefinedBy <https://w3id.org/smn> ;
   iao:0000119 "Migrated and relabeled from GC DFO Salmon Ontology term gcdfo:Age7YearClass."@en ;
   dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/f08133685563bb89deac9c290266e120f277ec68/ontology/dfo-salmon.ttl> .
+
+
+#################################################################
+# Method scheme (migrated from module 02 OWL classes, 2026-08-13)
+#
+# Alignment-pass step 2, ordered by Brett: methods are pick-list
+# concepts, not class hierarchies. IRIs are unchanged from their
+# owl:Class era; each concept is additionally instance-typed
+# sosa:Procedure so sosa:usedProcedure stays type-correct
+# (CONVENTIONS section 3, instance-typing rule). Concepts that had no
+# definition as classes still have none: definitions are not invented
+# during migration (CONVENTIONS section 10).
+#################################################################
+
+smn:MethodScheme a skos:ConceptScheme ;
+  skos:prefLabel "Method scheme"@en ;
+  skos:hasTopConcept smn:EnumerationMethod, smn:FishLengthMeasurementMethod ;
+  skos:definition "Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11)."@en ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:EnumerationMethod a skos:Concept, sosa:Procedure ;
+  skos:prefLabel "Enumeration method"@en ;
+  skos:inScheme smn:MethodScheme ;
+  skos:topConceptOf smn:MethodScheme ;
+  skos:definition "A method used to enumerate or count salmon in the field."@en ;
+  rdfs:isDefinedBy <https://w3id.org/smn> ;
+  iao:0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en ;
+  dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> .
+
+smn:FishLengthMeasurementMethod a skos:Concept, sosa:Procedure ;
+  skos:prefLabel "Fish length measurement method"@en ;
+  skos:inScheme smn:MethodScheme ;
+  skos:topConceptOf smn:MethodScheme ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:FishForkLengthMeasurementMethod a skos:Concept, sosa:Procedure ;
+  skos:prefLabel "Fish fork-length measurement method"@en ;
+  skos:inScheme smn:MethodScheme ;
+  skos:broader smn:FishLengthMeasurementMethod ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:ForkLengthMeasurementMethod a skos:Concept, sosa:Procedure ;
+  skos:prefLabel "Fork-length measurement method"@en ;
+  skos:inScheme smn:MethodScheme ;
+  skos:broader smn:FishForkLengthMeasurementMethod ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:ForkLengthMeasurementFieldMethod a skos:Concept, sosa:Procedure ;
+  skos:prefLabel "Fork-length field method"@en ;
+  skos:inScheme smn:MethodScheme ;
+  skos:broader smn:ForkLengthMeasurementMethod ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:ForkLengthMeasurementLabMethod a skos:Concept, sosa:Procedure ;
+  skos:prefLabel "Fork-length lab method"@en ;
+  skos:inScheme smn:MethodScheme ;
+  skos:broader smn:ForkLengthMeasurementMethod ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+#################################################################
+# Statistical modifier scheme (new, 2026-08-13)
+#
+# Alignment-pass step 5. Uses I-ADOPT's own language and class per
+# Brett's 2026-08-13 decision: each concept is instance-typed
+# iadopt:StatisticalModifier (I-ADOPT 1.1.0), and the SDP column
+# statistical_modifier_iri resolves here. ODM2 AggregationStatistic
+# links are advisory Tier-3 only: that vocabulary's hosting is
+# HTTP-only and intermittently unreachable, so it is referenced, not
+# depended on. New terms, so definitions are authored here.
+#################################################################
+
+smn:StatisticalModifierScheme a skos:ConceptScheme ;
+  skos:prefLabel "Statistical modifier scheme"@en ;
+  skos:hasTopConcept smn:MeanStatisticalModifier, smn:MedianStatisticalModifier,
+    smn:MinimumStatisticalModifier, smn:MaximumStatisticalModifier,
+    smn:TotalStatisticalModifier, smn:CountStatisticalModifier,
+    smn:PeakStatisticalModifier ;
+  skos:definition "Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring."@en ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:MeanStatisticalModifier a skos:Concept, iadopt:StatisticalModifier ;
+  skos:prefLabel "Mean"@en ;
+  skos:inScheme smn:StatisticalModifierScheme ;
+  skos:topConceptOf smn:StatisticalModifierScheme ;
+  skos:definition "The reported value is the arithmetic mean of the summarized observations."@en ;
+  skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/average> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:MedianStatisticalModifier a skos:Concept, iadopt:StatisticalModifier ;
+  skos:prefLabel "Median"@en ;
+  skos:inScheme smn:StatisticalModifierScheme ;
+  skos:topConceptOf smn:StatisticalModifierScheme ;
+  skos:definition "The reported value is the median of the summarized observations."@en ;
+  skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/median> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:MinimumStatisticalModifier a skos:Concept, iadopt:StatisticalModifier ;
+  skos:prefLabel "Minimum"@en ;
+  skos:inScheme smn:StatisticalModifierScheme ;
+  skos:topConceptOf smn:StatisticalModifierScheme ;
+  skos:definition "The reported value is the minimum of the summarized observations."@en ;
+  skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/minimum> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:MaximumStatisticalModifier a skos:Concept, iadopt:StatisticalModifier ;
+  skos:prefLabel "Maximum"@en ;
+  skos:inScheme smn:StatisticalModifierScheme ;
+  skos:topConceptOf smn:StatisticalModifierScheme ;
+  skos:definition "The reported value is the maximum of the summarized observations."@en ;
+  skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/maximum> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:TotalStatisticalModifier a skos:Concept, iadopt:StatisticalModifier ;
+  skos:prefLabel "Total"@en ;
+  skos:inScheme smn:StatisticalModifierScheme ;
+  skos:topConceptOf smn:StatisticalModifierScheme ;
+  skos:definition "The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement."@en ;
+  skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/cumulative> ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:CountStatisticalModifier a skos:Concept, iadopt:StatisticalModifier ;
+  skos:prefLabel "Count"@en ;
+  skos:inScheme smn:StatisticalModifierScheme ;
+  skos:topConceptOf smn:StatisticalModifierScheme ;
+  skos:definition "The reported value is the number of summarized observations or individuals, as counted rather than estimated."@en ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .
+
+smn:PeakStatisticalModifier a skos:Concept, iadopt:StatisticalModifier ;
+  skos:prefLabel "Peak"@en ;
+  skos:inScheme smn:StatisticalModifierScheme ;
+  skos:topConceptOf smn:StatisticalModifierScheme ;
+  skos:definition "The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey."@en ;
+  rdfs:isDefinedBy <https://w3id.org/smn> .

--- a/ontology/shapes/method-shapes.ttl
+++ b/ontology/shapes/method-shapes.ttl
@@ -1,0 +1,32 @@
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix smn:  <https://w3id.org/smn/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+
+<https://w3id.org/smn/shapes/method-shapes> a owl:Ontology ;
+  rdfs:label "Salmon Domain Ontology method shapes"@en ;
+  rdfs:comment "SHACL shapes carrying the value constraints that the 2026-08-13 methods-as-SKOS migration moved out of OWL. When method concepts became individuals, the module-02 restrictions could only target the generic sosa:Procedure class; the specific 'must be an enumeration method' semantics live here instead, expressed the SKOS-native way (a skos:broader* path into the concept hierarchy). Validation wiring into CI is part of the S9 tooling work; the shape is normative in intent from the moment it is merged."@en .
+
+smn:AggregatedMeasurementShape a sh:NodeShape ;
+  rdfs:label "Aggregated measurement based-on shape"@en ;
+  sh:targetClass smn:AggregatedMeasurement ;
+  sh:property [
+    sh:path smn:basedOn ;
+    sh:node smn:EnumerationMethodValueShape ;
+    sh:message "smn:basedOn values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme."@en ;
+  ] .
+
+smn:EnumerationMethodValueShape a sh:NodeShape ;
+  rdfs:label "Enumeration method value shape"@en ;
+  sh:property [
+    sh:path [ sh:zeroOrMorePath skos:broader ] ;
+    sh:qualifiedValueShape [ sh:hasValue smn:EnumerationMethod ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:message "The value must reach smn:EnumerationMethod via skos:broader (zero or more steps)."@en ;
+  ] ;
+  sh:property [
+    sh:path skos:inScheme ;
+    sh:hasValue smn:MethodScheme ;
+    sh:message "The value must be a concept in smn:MethodScheme."@en ;
+  ] .

--- a/salmon-domain-ontology.ttl
+++ b/salmon-domain-ontology.ttl
@@ -595,7 +595,7 @@ sosa:Sample skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
 
 <https://w3id.org/smn/AggregatedMeasurement> a owl:Class ;
     rdfs:label "Aggregated measurement"@en ;
-    rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en ;
+    rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration. The specific constraint — values must be method concepts at or below smn:EnumerationMethod in smn:MethodScheme — is normative and lives in ontology/shapes/method-shapes.ttl (smn:AggregatedMeasurementShape), expressed as a skos:broader* path, since someValuesFrom cannot range over concept individuals."@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onProperty <https://w3id.org/smn/basedOn> ;

--- a/salmon-domain-ontology.ttl
+++ b/salmon-domain-ontology.ttl
@@ -20,8 +20,6 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
 
 <https://w3id.org/iadopt/ont/Property> skos:closeMatch sosa:Property .
 
-<https://w3id.org/iadopt/ont/StatisticalModifier> a owl:Class .
-
 <https://w3id.org/iadopt/ont/Variable> a owl:Class ;
     skos:closeMatch sosa:ObservableProperty .
 
@@ -213,15 +211,19 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
             owl:someValuesFrom <https://w3id.org/smn/forkLength> ],
         <https://w3id.org/smn/FishLengthMeasurementType> .
 
-<https://w3id.org/smn/ForkLengthMeasurementFieldMethod> a owl:Class ;
-    rdfs:label "Fork-length field method"@en ;
+<https://w3id.org/smn/ForkLengthMeasurementFieldMethod> a skos:Concept,
+        sosa:Procedure ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
-    rdfs:subClassOf <https://w3id.org/smn/ForkLengthMeasurementMethod> .
+    skos:broader <https://w3id.org/smn/ForkLengthMeasurementMethod> ;
+    skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+    skos:prefLabel "Fork-length field method"@en .
 
-<https://w3id.org/smn/ForkLengthMeasurementLabMethod> a owl:Class ;
-    rdfs:label "Fork-length lab method"@en ;
+<https://w3id.org/smn/ForkLengthMeasurementLabMethod> a skos:Concept,
+        sosa:Procedure ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
-    rdfs:subClassOf <https://w3id.org/smn/ForkLengthMeasurementMethod> .
+    skos:broader <https://w3id.org/smn/ForkLengthMeasurementMethod> ;
+    skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+    skos:prefLabel "Fork-length lab method"@en .
 
 <https://w3id.org/smn/FreshwaterAgeDimension> a skos:Concept ;
     ns1:IAO_0000119 "Adapted from GC DFO Salmon Ontology term gcdfo:FreshwaterAgeDimension."@en ;
@@ -593,16 +595,35 @@ sosa:Sample skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
 
 <https://w3id.org/smn/AggregatedMeasurement> a owl:Class ;
     rdfs:label "Aggregated measurement"@en ;
+    rdfs:comment "The based-on restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration; the intended values are concepts from module 07's smn:MethodScheme (e.g. smn:EnumerationMethod)."@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onProperty <https://w3id.org/smn/basedOn> ;
-            owl:someValuesFrom <https://w3id.org/smn/EnumerationMethod> ],
+            owl:someValuesFrom sosa:Procedure ],
         <https://w3id.org/smn/Measurement> .
 
 <https://w3id.org/smn/BodyShape> a owl:Class ;
     rdfs:label "Body shape"@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/Characteristic> .
+
+<https://w3id.org/smn/CountStatisticalModifier> a skos:Concept,
+        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:definition "The reported value is the number of summarized observations or individuals, as counted rather than estimated."@en ;
+    skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+    skos:prefLabel "Count"@en ;
+    skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+<https://w3id.org/smn/EnumerationMethod> a skos:Concept,
+        sosa:Procedure ;
+    ns1:IAO_0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en ;
+    dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:definition "A method used to enumerate or count salmon in the field."@en ;
+    skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+    skos:prefLabel "Enumeration method"@en ;
+    skos:topConceptOf <https://w3id.org/smn/MethodScheme> .
 
 <https://w3id.org/smn/ExploitationRate> a owl:Class ;
     rdfs:label "Exploitation rate"@en ;
@@ -612,10 +633,12 @@ sosa:Sample skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/TargetOrLimitRateOrAbundance> .
 
-<https://w3id.org/smn/FishForkLengthMeasurementMethod> a owl:Class ;
-    rdfs:label "Fish fork-length measurement method"@en ;
+<https://w3id.org/smn/FishForkLengthMeasurementMethod> a skos:Concept,
+        sosa:Procedure ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
-    rdfs:subClassOf <https://w3id.org/smn/FishLengthMeasurementMethod> .
+    skos:broader <https://w3id.org/smn/FishLengthMeasurementMethod> ;
+    skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+    skos:prefLabel "Fish fork-length measurement method"@en .
 
 <https://w3id.org/smn/FishingType> a owl:Class ;
     rdfs:label "Fishing type"@en ;
@@ -632,10 +655,54 @@ sosa:Sample skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/Characteristic> .
 
+<https://w3id.org/smn/MaximumStatisticalModifier> a skos:Concept,
+        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/maximum> ;
+    skos:definition "The reported value is the maximum of the summarized observations."@en ;
+    skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+    skos:prefLabel "Maximum"@en ;
+    skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+<https://w3id.org/smn/MeanStatisticalModifier> a skos:Concept,
+        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/average> ;
+    skos:definition "The reported value is the arithmetic mean of the summarized observations."@en ;
+    skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+    skos:prefLabel "Mean"@en ;
+    skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+<https://w3id.org/smn/MedianStatisticalModifier> a skos:Concept,
+        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/median> ;
+    skos:definition "The reported value is the median of the summarized observations."@en ;
+    skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+    skos:prefLabel "Median"@en ;
+    skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
+<https://w3id.org/smn/MinimumStatisticalModifier> a skos:Concept,
+        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/minimum> ;
+    skos:definition "The reported value is the minimum of the summarized observations."@en ;
+    skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+    skos:prefLabel "Minimum"@en ;
+    skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
 <https://w3id.org/smn/Observation> a owl:Class ;
     rdfs:label "Observation"@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf sosa:Observation .
+
+<https://w3id.org/smn/PeakStatisticalModifier> a skos:Concept,
+        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:definition "The reported value is the peak (highest single observation event) across the summarized series, such as a peak live count in a spawner survey."@en ;
+    skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+    skos:prefLabel "Peak"@en ;
+    skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
 
 <https://w3id.org/smn/ReferencePoint> a owl:Class ;
     rdfs:label "Reference point"@en ;
@@ -684,11 +751,20 @@ sosa:Sample skos:closeMatch <http://rs.tdwg.org/dwc/terms/MaterialEntity>,
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf ns1:IAO_0000109 .
 
+<https://w3id.org/smn/TotalStatisticalModifier> a skos:Concept,
+        <https://w3id.org/iadopt/ont/StatisticalModifier> ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:closeMatch <http://vocabulary.odm2.org/aggregationstatistic/cumulative> ;
+    skos:definition "The reported value is the sum or cumulative total of the summarized observations, such as an annual total catch or cumulative escapement."@en ;
+    skos:inScheme <https://w3id.org/smn/StatisticalModifierScheme> ;
+    skos:prefLabel "Total"@en ;
+    skos:topConceptOf <https://w3id.org/smn/StatisticalModifierScheme> .
+
 <https://w3id.org/smn/basedOn> a owl:ObjectProperty ;
     rdfs:label "based on"@en ;
     rdfs:domain <https://w3id.org/smn/AggregatedMeasurement> ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
-    rdfs:range <https://w3id.org/smn/EnumerationMethod> .
+    rdfs:range sosa:Procedure .
 
 <https://w3id.org/smn/broodYear> a qb:DimensionProperty,
         owl:DatatypeProperty ;
@@ -753,8 +829,6 @@ ns1:NCBITaxon_8018 rdfs:subClassOf ns1:NCBITaxon_8015 .
 
 geo:Feature rdfs:subClassOf sosa:FeatureOfInterest .
 
-sosa:Procedure skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
-
 <https://w3id.org/smn/Abundance> a owl:Class ;
     rdfs:label "Abundance"@en ;
     ns1:IAO_0000115 "A characteristic representing the quantity of salmon or other organisms associated with a defined entity, place, and time."@en ;
@@ -774,28 +848,24 @@ sosa:Procedure skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <http://rs.tdwg.org/dwc/terms/Organism> .
 
-<https://w3id.org/smn/EnumerationMethod> a owl:Class ;
-    rdfs:label "Enumeration method"@en ;
-    ns1:IAO_0000115 "A method used to enumerate or count salmon in the field"@en ;
-    ns1:IAO_0000119 "GC DFO Salmon Ontology release 0.0.2, term gcdfo:EnumerationMethod."@en ;
-    dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/c7a54251eb8f673052fed61f9ca2624e557249c7/docs/releases/0.0.2/gcdfo.ttl> ;
-    rdfs:isDefinedBy <https://w3id.org/smn> ;
-    rdfs:subClassOf sosa:Procedure .
-
 <https://w3id.org/smn/EventType> a owl:Class ;
     rdfs:label "Event type"@en ;
     ns1:IAO_0000115 "A class used to categorize fisheries or survey event instances by operational type."@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> .
 
-<https://w3id.org/smn/FishLengthMeasurementMethod> a owl:Class ;
-    rdfs:label "Fish length measurement method"@en ;
+<https://w3id.org/smn/FishLengthMeasurementMethod> a skos:Concept,
+        sosa:Procedure ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
-    rdfs:subClassOf sosa:Procedure .
+    skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+    skos:prefLabel "Fish length measurement method"@en ;
+    skos:topConceptOf <https://w3id.org/smn/MethodScheme> .
 
-<https://w3id.org/smn/ForkLengthMeasurementMethod> a owl:Class ;
-    rdfs:label "Fork-length measurement method"@en ;
+<https://w3id.org/smn/ForkLengthMeasurementMethod> a skos:Concept,
+        sosa:Procedure ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
-    rdfs:subClassOf <https://w3id.org/smn/FishForkLengthMeasurementMethod> .
+    skos:broader <https://w3id.org/smn/FishForkLengthMeasurementMethod> ;
+    skos:inScheme <https://w3id.org/smn/MethodScheme> ;
+    skos:prefLabel "Fork-length measurement method"@en .
 
 <https://w3id.org/smn/MorphologicalCharacteristic> a owl:Class ;
     rdfs:label "Morphological characteristic"@en ;
@@ -863,13 +933,14 @@ sosa:Sampling skos:broadMatch <http://rs.tdwg.org/dwc/terms/Event> .
 
 <https://w3id.org/smn/FishLengthMeasurementType> a owl:Class ;
     rdfs:label "Fish length measurement type"@en ;
+    rdfs:comment "The used-procedure restriction targets sosa:Procedure since the 2026-08-13 methods-as-SKOS migration: the specific length-method concepts are individuals in module 07's smn:MethodScheme, and someValuesFrom needs a class."@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:onProperty sosa:observedProperty ;
             owl:someValuesFrom <https://w3id.org/smn/FishLength> ],
         [ a owl:Restriction ;
             owl:onProperty sosa:usedProcedure ;
-            owl:someValuesFrom <https://w3id.org/smn/FishLengthMeasurementMethod> ],
+            owl:someValuesFrom sosa:Procedure ],
         <https://w3id.org/smn/Measurement> .
 
 <https://w3id.org/smn/ReportingOrManagementStratum> a owl:Class ;
@@ -1037,6 +1108,8 @@ sosa:Sampling skos:broadMatch <http://rs.tdwg.org/dwc/terms/Event> .
 
 <https://w3id.org/iadopt/ont/Constraint> a owl:Class .
 
+<https://w3id.org/iadopt/ont/StatisticalModifier> a owl:Class .
+
 <https://w3id.org/smn/AgeClassValue> a skos:Concept ;
     ns1:IAO_0000119 "Adapted and relabeled from GC DFO Salmon Ontology term gcdfo:AgeClassValue."@en ;
     dcterms:source <https://github.com/dfo-pacific-science/dfo-salmon-ontology/blob/f08133685563bb89deac9c290266e120f277ec68/ontology/dfo-salmon.ttl> ;
@@ -1057,6 +1130,27 @@ sosa:Sampling skos:broadMatch <http://rs.tdwg.org/dwc/terms/Event> .
     skos:hasTopConcept <https://w3id.org/smn/AgeClassValue> ;
     skos:prefLabel "Age-class value scheme"@en ;
     skos:scopeNote "An age-class value is an age coordinate, not a cohort or year class. Mint additional values only when supported by a use case."@en .
+
+<https://w3id.org/smn/MethodScheme> a skos:ConceptScheme ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:definition "Controlled vocabulary of shared, policy-neutral salmon observation and measurement methods. Organization- or program-specific method taxonomies remain profile-scoped (CONVENTIONS section 11)."@en ;
+    skos:hasTopConcept <https://w3id.org/smn/EnumerationMethod>,
+        <https://w3id.org/smn/FishLengthMeasurementMethod> ;
+    skos:prefLabel "Method scheme"@en .
+
+sosa:Procedure skos:closeMatch <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
+
+<https://w3id.org/smn/StatisticalModifierScheme> a skos:ConceptScheme ;
+    rdfs:isDefinedBy <https://w3id.org/smn> ;
+    skos:definition "Controlled vocabulary of statistical modifiers stating what a reported value represents across the observations it summarizes (mean, median, minimum, maximum, total, count, peak). A statistical modifier is part of variable identity — daily mean and daily maximum temperature are different variables — unlike a method, which describes the act of measuring."@en ;
+    skos:hasTopConcept <https://w3id.org/smn/CountStatisticalModifier>,
+        <https://w3id.org/smn/MaximumStatisticalModifier>,
+        <https://w3id.org/smn/MeanStatisticalModifier>,
+        <https://w3id.org/smn/MedianStatisticalModifier>,
+        <https://w3id.org/smn/MinimumStatisticalModifier>,
+        <https://w3id.org/smn/PeakStatisticalModifier>,
+        <https://w3id.org/smn/TotalStatisticalModifier> ;
+    skos:prefLabel "Statistical modifier scheme"@en .
 
 <https://w3id.org/smn> a owl:Ontology ;
     rdfs:label "Salmon Domain Ontology (modular build)"@en ;


### PR DESCRIPTION
**Step 2 — methods-as-SKOS** (ordered by Brett 2026-08-13): the six method OWL classes in module 02 migrate to SKOS concepts in module 07's new `smn:MethodScheme` — IRIs unchanged, hierarchy via `skos:broader`, each concept instance-typed `sosa:Procedure` (CONVENTIONS §3 instance-typing rule). Module 02's restrictions and `smn:basedOn` retarget `sosa:Procedure`.

**Effect:** the live cross-repo pun is resolved — gcdfo already types `smn:EnumerationMethod` as `skos:Concept`, and the flat closure now has **zero IRIs typed both `owl:Class` and `skos:Concept`** (verified). The PSC vocabulary's stated blocker on mapping to smn (`sdo-alignment-gap.md`: method anchor is an owl:Class) no longer applies; their doc update + psc→smn SSSOM rows are step 4.

**Step 5 — `smn:StatisticalModifierScheme`**: seven concepts (mean, median, minimum, maximum, total, count, peak), each instance-typed `iadopt:StatisticalModifier` per I-ADOPT 1.1.0 — Brett's decision to use I-ADOPT's own language and class — with advisory ODM2 links where terms exist. The SDP `statistical_modifier_iri` column resolves here.

Retype records in `docs/migrations/smn-internal-renames.csv`; publication surface regenerated; `make ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)