### PR TITLE
S9 step 1b: CI gates and tooling hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install Python deps
         run: |
-          pip install rdflib
+          pip install rdflib pyshacl
 
       - name: Install docs build tools
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,32 @@ jobs:
 
       - name: Install Python deps
         run: |
-          pip install rdflib
+          pip install rdflib pyshacl
 
       - name: Run validation bundle
         run: |
           make test
+
+  reasoner-gate:
+    name: Reasoner gate (ELK)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Install ROBOT
+        run: |
+          make install-robot
+
+      - name: Run ELK over the modular build
+        run: |
+          make verify-reasoner
 
   publication-surface-drift-check:
     name: Verify published docs artifacts

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,23 @@ verify-ontology-parse:
 verify-year-age-semantic-contract:
 	@python3 scripts/verify_year_age_semantic_contract.py
 
+verify-case-study-modules:
+	@python3 scripts/build_rda_case_study_modules.py --check
+
+verify-mapping-policy:
+	@python3 scripts/verify_mapping_policy.py
+
+verify-method-shapes:
+	@python3 scripts/verify_method_shapes.py
+
+verify-reasoner: check-robot
+	@echo "Running ELK reasoner over the modular build (catalog-resolved imports)..."
+	@tmp=$$(mktemp -u).ttl; \
+	java -jar $(ROBOT_JAR) merge --catalog ontology/catalog-v001.xml --input $(ONTOLOGY_TTL) \
+	  reason --reasoner ELK --output $$tmp && rm -f $$tmp
+	@echo "Reasoner gate passed: consistent, no unsatisfiable classes."
+
 verify-flat-ttl:
-	@python3 scripts/build_rda_case_study_modules.py >/dev/null
 	@tmp=$$(mktemp); \
 	python3 scripts/build_flat_smn_ttl.py --source $(ONTOLOGY_TTL) --output $$tmp; \
 	if ! cmp -s $(COMPOSE_FLAT_TTL) $$tmp; then \
@@ -116,7 +131,7 @@ verify-doc-term-anchors:
 verify-doc-version-metadata:
 	@python3 scripts/verify_widoco_version_metadata.py
 
-test: verify-ontology-parse verify-year-age-semantic-contract verify-flat-ttl verify-doc-term-anchors verify-doc-version-metadata
+test: verify-ontology-parse verify-case-study-modules verify-year-age-semantic-contract verify-mapping-policy verify-method-shapes verify-flat-ttl verify-doc-term-anchors verify-doc-version-metadata
 	@echo "Validation bundle completed."
 
 ci: docs-refresh test

--- a/knowledge/data/builds-and-import-graph.md
+++ b/knowledge/data/builds-and-import-graph.md
@@ -45,16 +45,18 @@ header comment distinguishes them, which invites wrong-file edits.
 ## Generated vs hand-authored mixing
 
 - Bridge modules `08`/`09` under `ontology/modules/` are **generated**
-  (concatenated from `ontology/case-studies/` fragments) but sit beside
-  hand-authored modules; CI's drift gate (`make verify-generated-artifacts`,
-  Makefile:126) covers only `docs/` and the root flat TTL — a hand-edit to
-  08/09 passes CI and is silently clobbered by the next `make test`.
-- `make verify-flat-ttl` (and hence `make test` / `make ci`) **mutates the
-  working tree** (rewrites modules 08/09) — a verify target with write
-  side-effects (Makefile:102).
-- Every `REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit)`
-  block has **no generator**: `git log -S` shows they entered in authored
-  commit `2549f74` and no script writes or refreshes them.
+  (concatenated from `ontology/case-studies/` fragments) beside
+  hand-authored modules. ~~Drift-gate gap and verify-mutates-source~~
+  **Fixed 2026-08-13 (step 1b):** `make test` runs
+  `build_rda_case_study_modules.py --check` (compose in memory, diff, fail
+  on drift) — verification is read-only and hand-edits to 08/09 now fail CI.
+- ~~Phantom "auto-generated" markers~~ **Fixed 2026-08-13:** the markers
+  (which never had a generator — authored in `2549f74`) are replaced with
+  honest hand-authored markers in the fragments.
+- **CI gates since step 1b:** `verify_mapping_policy.py` (CONVENTIONS §5b:
+  foreign-subject statements, tier-mixing per-file and across the spine,
+  dual typing), `verify_method_shapes.py` (pyshacl behavioural fixture),
+  and an ELK reasoner-gate job over the catalog-resolved closure.
 
 ## w3id dereference gaps (live-checked 2026-08-12)
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -22,3 +22,8 @@
   enumeration-method value constraint, SKOS-native via skos:broader*,
   behaviourally tested with pyshacl) and refreshed the conventions card's
   module-07 inventory (10 schemes / 49 concepts).
+- 2026-08-13 — S9 step 1b (tooling): verify targets are read-only, generated
+  modules 08/09 gain a drift gate, CONVENTIONS 5b checks + method-shapes
+  behavioural check wired into make test and CI, new ELK reasoner-gate CI job
+  (passes: consistent, zero unsatisfiable classes), views documented as
+  non-dereferenceable identifiers.

--- a/ontology/case-studies/rda-juvenile-condition/08-rda-hakai-measurement-methods.ttl
+++ b/ontology/case-studies/rda-juvenile-condition/08-rda-hakai-measurement-methods.ttl
@@ -47,8 +47,8 @@ hakai:Fork_Length_Lab_Measurement a skos:Concept ;
   dcterms:source <https://drive.google.com/file/d/1-WPKX6XwDiyLGZGT-bcF36N4ankpNi1o/view> ;
   prov:wasDerivedFrom <https://drive.google.com/file/d/1-WPKX6XwDiyLGZGT-bcF36N4ankpNi1o/view> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/hakai/Fork_Length_Field_Measurement>
   <http://www.w3.org/2000/01/rdf-schema#label> "Fork Length Field Measurement"@en ;
@@ -74,4 +74,4 @@ hakai:Fork_Length_Lab_Measurement a skos:Concept ;
   <http://www.w3.org/2004/02/skos/core#definition> "Hakai profile concept for the laboratory protocol used to obtain fork-length measurements."@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/hakai> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---

--- a/ontology/case-studies/rda-juvenile-condition/08-rda-hakai-method-scheme.ttl
+++ b/ontology/case-studies/rda-juvenile-condition/08-rda-hakai-method-scheme.ttl
@@ -10,11 +10,11 @@ rda:HakaiJSPMeasurementTermScheme a skos:ConceptScheme ;
   skos:hasTopConcept <https://w3id.org/smn/profile/hakai/Fork_Length_Measurement_Method> ;
   dcterms:source <https://drive.google.com/file/d/1-WPKX6XwDiyLGZGT-bcF36N4ankpNi1o/view> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/rda-case-study/HakaiJSPMeasurementTermScheme>
   <http://www.w3.org/2000/01/rdf-schema#label> "Hakai JSP measurement term scheme (RDA case-study bridge)"@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/rda-case-study> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---

--- a/ontology/case-studies/rda-juvenile-condition/09-rda-neville-constraints.ttl
+++ b/ontology/case-studies/rda-juvenile-condition/09-rda-neville-constraints.ttl
@@ -34,8 +34,8 @@ neville:NumberSampled a skos:Concept ;
   skos:relatedMatch smn:AggregatedMeasurement ;
   dcterms:source <https://docs.google.com/spreadsheets/d/10Bd7bhTJvOOr-V1wK6YyAj9A4PvxKKpumEvcyIobBlw/edit> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/neville/NumberSampled>
   <http://www.w3.org/2000/01/rdf-schema#label> "Number Sampled"@en ;
@@ -57,4 +57,4 @@ neville:NumberSampled a skos:Concept ;
   <http://www.w3.org/2004/02/skos/core#definition> "Neville profile concept representing the standard deviation of juvenile salmon weight measurements in grams."@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/neville> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---

--- a/ontology/case-studies/rda-juvenile-condition/09-rda-neville-entities.ttl
+++ b/ontology/case-studies/rda-juvenile-condition/09-rda-neville-entities.ttl
@@ -75,8 +75,8 @@ neville:SurveyArea a skos:Concept ;
   skos:closeMatch smn:GeographicFeature ;
   dcterms:source <https://docs.google.com/spreadsheets/d/10Bd7bhTJvOOr-V1wK6YyAj9A4PvxKKpumEvcyIobBlw/edit> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/neville/Age>
   <http://www.w3.org/2000/01/rdf-schema#label> "Age"@en ;
@@ -117,4 +117,4 @@ neville:SurveyArea a skos:Concept ;
   <http://www.w3.org/2000/01/rdf-schema#label> "Neville decomposition term scheme (RDA case-study bridge)"@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/rda-case-study> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---

--- a/ontology/case-studies/rda-juvenile-condition/09-rda-neville-observations.ttl
+++ b/ontology/case-studies/rda-juvenile-condition/09-rda-neville-observations.ttl
@@ -61,8 +61,8 @@ neville:AverageWeight_g a skos:Concept ;
   skos:relatedMatch smn:FishWeight ;
   dcterms:source <https://docs.google.com/spreadsheets/d/10Bd7bhTJvOOr-V1wK6YyAj9A4PvxKKpumEvcyIobBlw/edit> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/neville/ADCWT>
   <http://www.w3.org/2000/01/rdf-schema#label> "ADCWT"@en ;
@@ -94,4 +94,4 @@ neville:AverageWeight_g a skos:Concept ;
   <http://www.w3.org/2004/02/skos/core#definition> "Neville profile concept capturing observed wounds, parasite load, or other external condition notes."@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/neville> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---

--- a/ontology/modules/08-rda-case-study-profile-bridges.ttl
+++ b/ontology/modules/08-rda-case-study-profile-bridges.ttl
@@ -29,14 +29,14 @@ rda:HakaiJSPMeasurementTermScheme a skos:ConceptScheme ;
   skos:hasTopConcept <https://w3id.org/smn/profile/hakai/Fork_Length_Measurement_Method> ;
   dcterms:source <https://drive.google.com/file/d/1-WPKX6XwDiyLGZGT-bcF36N4ankpNi1o/view> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/rda-case-study/HakaiJSPMeasurementTermScheme>
   <http://www.w3.org/2000/01/rdf-schema#label> "Hakai JSP measurement term scheme (RDA case-study bridge)"@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/rda-case-study> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---
 # --- end ontology/case-studies/rda-juvenile-condition/08-rda-hakai-method-scheme.ttl ---
 
 # --- begin ontology/case-studies/rda-juvenile-condition/08-rda-hakai-measurement-methods.ttl ---
@@ -89,8 +89,8 @@ hakai:Fork_Length_Lab_Measurement a skos:Concept ;
   dcterms:source <https://drive.google.com/file/d/1-WPKX6XwDiyLGZGT-bcF36N4ankpNi1o/view> ;
   prov:wasDerivedFrom <https://drive.google.com/file/d/1-WPKX6XwDiyLGZGT-bcF36N4ankpNi1o/view> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/hakai/Fork_Length_Field_Measurement>
   <http://www.w3.org/2000/01/rdf-schema#label> "Fork Length Field Measurement"@en ;
@@ -116,5 +116,5 @@ hakai:Fork_Length_Lab_Measurement a skos:Concept ;
   <http://www.w3.org/2004/02/skos/core#definition> "Hakai profile concept for the laboratory protocol used to obtain fork-length measurements."@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/hakai> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---
 # --- end ontology/case-studies/rda-juvenile-condition/08-rda-hakai-measurement-methods.ttl ---

--- a/ontology/modules/09-rda-neville-decomposition-profile-bridges.ttl
+++ b/ontology/modules/09-rda-neville-decomposition-profile-bridges.ttl
@@ -98,8 +98,8 @@ neville:SurveyArea a skos:Concept ;
   skos:closeMatch smn:GeographicFeature ;
   dcterms:source <https://docs.google.com/spreadsheets/d/10Bd7bhTJvOOr-V1wK6YyAj9A4PvxKKpumEvcyIobBlw/edit> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/neville/Age>
   <http://www.w3.org/2000/01/rdf-schema#label> "Age"@en ;
@@ -140,7 +140,7 @@ neville:SurveyArea a skos:Concept ;
   <http://www.w3.org/2000/01/rdf-schema#label> "Neville decomposition term scheme (RDA case-study bridge)"@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/rda-case-study> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---
 # --- end ontology/case-studies/rda-juvenile-condition/09-rda-neville-entities.ttl ---
 
 # --- begin ontology/case-studies/rda-juvenile-condition/09-rda-neville-observations.ttl ---
@@ -207,8 +207,8 @@ neville:AverageWeight_g a skos:Concept ;
   skos:relatedMatch smn:FishWeight ;
   dcterms:source <https://docs.google.com/spreadsheets/d/10Bd7bhTJvOOr-V1wK6YyAj9A4PvxKKpumEvcyIobBlw/edit> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/neville/ADCWT>
   <http://www.w3.org/2000/01/rdf-schema#label> "ADCWT"@en ;
@@ -240,7 +240,7 @@ neville:AverageWeight_g a skos:Concept ;
   <http://www.w3.org/2004/02/skos/core#definition> "Neville profile concept capturing observed wounds, parasite load, or other external condition notes."@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/neville> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---
 # --- end ontology/case-studies/rda-juvenile-condition/09-rda-neville-observations.ttl ---
 
 # --- begin ontology/case-studies/rda-juvenile-condition/09-rda-neville-constraints.ttl ---
@@ -280,8 +280,8 @@ neville:NumberSampled a skos:Concept ;
   skos:relatedMatch smn:AggregatedMeasurement ;
   dcterms:source <https://docs.google.com/spreadsheets/d/10Bd7bhTJvOOr-V1wK6YyAj9A4PvxKKpumEvcyIobBlw/edit> .
 
-# --- REQUIRED ANNOTATION BACKFILL (auto-generated; do not hand-edit) ---
-# Added to enforce required term metadata parity with DFO conventions.
+# --- Required annotation backfill (hand-authored 2026-05; markers kept for provenance) ---
+# Added to meet the shared annotation-completeness convention (CONVENTIONS section 10).
 
 <https://w3id.org/smn/profile/neville/NumberSampled>
   <http://www.w3.org/2000/01/rdf-schema#label> "Number Sampled"@en ;
@@ -303,5 +303,5 @@ neville:NumberSampled a skos:Concept ;
   <http://www.w3.org/2004/02/skos/core#definition> "Neville profile concept representing the standard deviation of juvenile salmon weight measurements in grams."@en ;
   <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <https://w3id.org/smn/profile/neville> .
 
-# --- END REQUIRED ANNOTATION BACKFILL ---
+# --- end annotation backfill ---
 # --- end ontology/case-studies/rda-juvenile-condition/09-rda-neville-constraints.ttl ---

--- a/ontology/views/README.md
+++ b/ontology/views/README.md
@@ -47,3 +47,13 @@ Use the shared core (`ontology/modules/01-07...`) when you want the canonical re
 These views were moved here from the DFO repo so the shared salmon mental model lives with the shared ontology, while DFO keeps a cleaner **core ontology + optional overlays** posture.
 
 Detailed publication mappings stay in the shared interoperability module and profile/case-study layers, not in this simple view.
+
+## View IRIs are identifiers, not web pages
+
+The view ontology IRIs (`https://w3id.org/smn/views/...`) and the `smnv:`
+fragment namespace deliberately have **no w3id rewrite rules**: they do not
+dereference on the web. They are stable identifiers resolved locally via
+`ontology/catalog-v001.xml` (and `ontology/views/catalog-v001.xml` when a
+view file is opened directly in Protégé). If a public dereference route is
+ever wanted, it needs per-file w3id rules, because the IRI path segments do
+not pattern-map onto the filenames.

--- a/scripts/build_rda_case_study_modules.py
+++ b/scripts/build_rda_case_study_modules.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Compose the case-study profile modules from split fragments."""
 
+import sys
 from pathlib import Path
 from textwrap import dedent
 
@@ -75,22 +76,43 @@ MODULE_SPECS = [
 ]
 
 
+def compose(spec) -> str:
+    lines = [spec["header"].rstrip()]
+    for fragment in spec["fragments"]:
+        fragment_text = fragment.read_text().strip()
+        if not fragment_text:
+            continue
+        relative_fragment = fragment.relative_to(ROOT).as_posix()
+        lines.append(f"# --- begin {relative_fragment} ---")
+        lines.append(fragment_text)
+        lines.append(f"# --- end {relative_fragment} ---")
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
 def main() -> None:
+    # --check: verification must not mutate the working tree. Compare the
+    # composed output against the committed module and fail on drift —
+    # this is also the drift gate for hand-edits to generated modules
+    # 08/09, which CI previously could not detect.
+    check = "--check" in sys.argv[1:]
+    drift = []
     for spec in MODULE_SPECS:
         output_path = spec["output"]
-        lines = [spec["header"].rstrip()]
-
-        for fragment in spec["fragments"]:
-            fragment_text = fragment.read_text().strip()
-            if not fragment_text:
-                continue
-            relative_fragment = fragment.relative_to(ROOT).as_posix()
-            lines.append(f"# --- begin {relative_fragment} ---")
-            lines.append(fragment_text)
-            lines.append(f"# --- end {relative_fragment} ---")
-            lines.append("")
-
-        output_path.write_text("\n".join(lines).strip() + "\n")
+        composed = compose(spec)
+        if check:
+            existing = output_path.read_text() if output_path.exists() else ""
+            if existing != composed:
+                drift.append(output_path.relative_to(ROOT).as_posix())
+        else:
+            output_path.write_text(composed)
+    if check and drift:
+        for path in drift:
+            print(f"Generated module out of sync with its fragments: {path}")
+        print("Run 'make compose-case-study-modules' and commit the result.")
+        raise SystemExit(1)
+    if check:
+        print("Generated case-study modules match their fragments.")
 
 
 if __name__ == "__main__":

--- a/scripts/verify_mapping_policy.py
+++ b/scripts/verify_mapping_policy.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Enforce CONVENTIONS section 5b mapping placement and coherence rules.
+
+Three checks, all CI-fatal:
+
+1. Foreign-subject logical axioms (subClassOf / subPropertyOf /
+   equivalentClass / equivalentProperty / sameAs) are permitted only in the
+   alignment modules. Core modules (01-07) and views must never state them.
+   Bare declaration stubs (``ex:Term a owl:Class .``) and documentation
+   annotations are allowed anywhere; the annotated NCBITaxon MIREOT mirror
+   in module 02 is an explicit exception.
+2. One strongest mapping per subject-object pair across the default build
+   spine: a pair may carry predicates from exactly one tier
+   (Tier 1 = subClassOf/subPropertyOf/equivalent*/sameAs,
+   Tier 2 = exactMatch, Tier 3 = closeMatch/broadMatch/narrowMatch/
+   relatedMatch). The alignment-main/alignment-research promotion-staging
+   exception is cross-module by construction and therefore not visible to
+   this spine-level check.
+3. Reasoner-clean typing invariant: no IRI in the flattened build may be
+   typed both owl:Class and skos:Concept (the dual-representation rule).
+"""
+
+from collections import defaultdict
+from pathlib import Path
+
+from rdflib import Graph, RDF, RDFS, OWL, URIRef
+from rdflib.namespace import SKOS
+
+ROOT = Path(__file__).resolve().parents[1]
+SMN = "https://w3id.org/smn"
+ALIGNMENT_MODULES = {
+    "alignment-main.ttl",
+    "alignment-upper.ttl",
+    "alignment-research.ttl",
+}
+SPINE = [
+    "01-entity-systematics.ttl",
+    "02-observation-measurement.ttl",
+    "03-assessment-benchmarks.ttl",
+    "04-management-governance.ttl",
+    "05-provenance-quality.ttl",
+    "06-data-interoperability.ttl",
+    "07-controlled-vocabularies.ttl",
+    "alignment-main.ttl",
+    "alignment-upper.ttl",
+]
+TIER1 = {
+    RDFS.subClassOf,
+    RDFS.subPropertyOf,
+    OWL.equivalentClass,
+    OWL.equivalentProperty,
+    OWL.sameAs,
+}
+TIER2 = {SKOS.exactMatch}
+TIER3 = {SKOS.closeMatch, SKOS.broadMatch, SKOS.narrowMatch, SKOS.relatedMatch}
+
+
+def check_foreign_subjects() -> list:
+    failures = []
+    paths = sorted((ROOT / "ontology" / "modules").glob("*.ttl")) + sorted(
+        (ROOT / "ontology" / "views").glob("*.ttl")
+    )
+    for path in paths:
+        if path.name in ALIGNMENT_MODULES:
+            continue
+        graph = Graph()
+        graph.parse(path, format="turtle")
+        for subject, predicate, obj in graph:
+            if not isinstance(subject, URIRef) or str(subject).startswith(SMN):
+                continue
+            if predicate in TIER1:
+                if path.name == "02-observation-measurement.ttl" and "NCBITaxon" in str(subject):
+                    continue  # annotated MIREOT mirror of the upstream taxon hierarchy
+                failures.append(
+                    f"{path.relative_to(ROOT)}: foreign-subject axiom "
+                    f"{subject.n3(graph.namespace_manager)} "
+                    f"{predicate.n3(graph.namespace_manager)} "
+                    f"{obj.n3(graph.namespace_manager)}"
+                )
+    return failures
+
+
+def check_tier_mixing() -> list:
+    graph = Graph()
+    for name in SPINE:
+        graph.parse(ROOT / "ontology" / "modules" / name, format="turtle")
+    tiers_by_pair = defaultdict(set)
+    for subject, predicate, obj in graph:
+        if not (isinstance(subject, URIRef) and isinstance(obj, URIRef)):
+            continue
+        if predicate in TIER1:
+            tiers_by_pair[(subject, obj)].add("1")
+        elif predicate in TIER2:
+            tiers_by_pair[(subject, obj)].add("2")
+        elif predicate in TIER3:
+            tiers_by_pair[(subject, obj)].add("3")
+    return [
+        f"tier-mixed pair (tiers {'/'.join(sorted(tiers))}): {s} -> {o}"
+        for (s, o), tiers in sorted(tiers_by_pair.items())
+        if len(tiers) > 1
+    ]
+
+
+def check_dual_typing() -> list:
+    graph = Graph()
+    graph.parse(ROOT / "salmon-domain-ontology.ttl", format="turtle")
+    classes = set(graph.subjects(RDF.type, OWL.Class))
+    concepts = set(graph.subjects(RDF.type, SKOS.Concept))
+    return [
+        f"IRI typed both owl:Class and skos:Concept: {iri}"
+        for iri in sorted(str(x) for x in classes & concepts if isinstance(x, URIRef))
+    ]
+
+
+def main() -> None:
+    failures = check_foreign_subjects() + check_tier_mixing() + check_dual_typing()
+    if failures:
+        for failure in failures:
+            print(failure)
+        raise SystemExit(1)
+    print("Mapping policy verified: no foreign-subject axioms outside alignment "
+          "modules, no tier-mixed pairs in the default spine, no dual-typed IRIs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_mapping_policy.py
+++ b/scripts/verify_mapping_policy.py
@@ -3,19 +3,17 @@
 
 Three checks, all CI-fatal:
 
-1. Foreign-subject logical axioms (subClassOf / subPropertyOf /
-   equivalentClass / equivalentProperty / sameAs) are permitted only in the
-   alignment modules. Core modules (01-07) and views must never state them.
-   Bare declaration stubs (``ex:Term a owl:Class .``) and documentation
-   annotations are allowed anywhere; the annotated NCBITaxon MIREOT mirror
-   in module 02 is an explicit exception.
-2. One strongest mapping per subject-object pair across the default build
-   spine: a pair may carry predicates from exactly one tier
-   (Tier 1 = subClassOf/subPropertyOf/equivalent*/sameAs,
-   Tier 2 = exactMatch, Tier 3 = closeMatch/broadMatch/narrowMatch/
-   relatedMatch). The alignment-main/alignment-research promotion-staging
-   exception is cross-module by construction and therefore not visible to
-   this spine-level check.
+1. Foreign-subject statements outside alignment modules: a subject smn does
+   not own may carry only documentation annotations (label/comment/seeAlso/
+   isDefinedBy) and bare declaration stubs. Everything else — Tier-1 axioms
+   AND instance-level property assertions — is confined to the alignment
+   modules; the annotated NCBITaxon MIREOT mirror in module 02 is the one
+   explicit exception.
+2. One strongest mapping per subject-object pair, checked two ways: within
+   every single module/view file (covers 08/09, alignment-research, views —
+   the promotion-staging exception is cross-module by definition and can
+   never apply within one file), and across the default build spine (which
+   excludes alignment-research, the documented staging exception).
 3. Reasoner-clean typing invariant: no IRI in the flattened build may be
    typed both owl:Class and skos:Concept (the dual-representation rule).
 """
@@ -55,6 +53,27 @@ TIER2 = {SKOS.exactMatch}
 TIER3 = {SKOS.closeMatch, SKOS.broadMatch, SKOS.narrowMatch, SKOS.relatedMatch}
 
 
+# Predicates a foreign-namespace subject may carry outside alignment
+# modules: declaration stubs and documentation annotations only.
+# Everything else — Tier-1 axioms AND instance-level property assertions
+# (the old `sosa:FeatureOfInterest sosa:hasSample sosa:Sample` class of
+# mistake) — must live in an alignment module (CONVENTIONS 5b rule 2).
+FOREIGN_ALLOWED_PREDICATES = {
+    RDFS.comment,
+    RDFS.label,
+    RDFS.seeAlso,
+    RDFS.isDefinedBy,
+}
+FOREIGN_ALLOWED_TYPE_OBJECTS = {
+    OWL.Class,
+    OWL.ObjectProperty,
+    OWL.DatatypeProperty,
+    OWL.AnnotationProperty,
+    OWL.NamedIndividual,
+    OWL.Ontology,
+}
+
+
 def check_foreign_subjects() -> list:
     failures = []
     paths = sorted((ROOT / "ontology" / "modules").glob("*.ttl")) + sorted(
@@ -68,22 +87,22 @@ def check_foreign_subjects() -> list:
         for subject, predicate, obj in graph:
             if not isinstance(subject, URIRef) or str(subject).startswith(SMN):
                 continue
-            if predicate in TIER1:
-                if path.name == "02-observation-measurement.ttl" and "NCBITaxon" in str(subject):
-                    continue  # annotated MIREOT mirror of the upstream taxon hierarchy
-                failures.append(
-                    f"{path.relative_to(ROOT)}: foreign-subject axiom "
-                    f"{subject.n3(graph.namespace_manager)} "
-                    f"{predicate.n3(graph.namespace_manager)} "
-                    f"{obj.n3(graph.namespace_manager)}"
-                )
+            if predicate in FOREIGN_ALLOWED_PREDICATES:
+                continue
+            if predicate == RDF.type and obj in FOREIGN_ALLOWED_TYPE_OBJECTS:
+                continue  # bare declaration stub
+            if path.name == "02-observation-measurement.ttl" and "NCBITaxon" in str(subject):
+                continue  # annotated MIREOT mirror of the upstream taxon hierarchy
+            failures.append(
+                f"{path.relative_to(ROOT)}: foreign-subject statement "
+                f"{subject.n3(graph.namespace_manager)} "
+                f"{predicate.n3(graph.namespace_manager)} "
+                f"{obj.n3(graph.namespace_manager)}"
+            )
     return failures
 
 
-def check_tier_mixing() -> list:
-    graph = Graph()
-    for name in SPINE:
-        graph.parse(ROOT / "ontology" / "modules" / name, format="turtle")
+def _pair_tiers(graph: Graph) -> dict:
     tiers_by_pair = defaultdict(set)
     for subject, predicate, obj in graph:
         if not (isinstance(subject, URIRef) and isinstance(obj, URIRef)):
@@ -94,11 +113,39 @@ def check_tier_mixing() -> list:
             tiers_by_pair[(subject, obj)].add("2")
         elif predicate in TIER3:
             tiers_by_pair[(subject, obj)].add("3")
-    return [
-        f"tier-mixed pair (tiers {'/'.join(sorted(tiers))}): {s} -> {o}"
-        for (s, o), tiers in sorted(tiers_by_pair.items())
-        if len(tiers) > 1
-    ]
+    return tiers_by_pair
+
+
+def check_tier_mixing() -> list:
+    failures = []
+    # (a) No pair mixes tiers WITHIN any single module or view file — this
+    # covers 08/09, alignment-research, and the views, where the
+    # promotion-staging exception (a cross-module pattern by definition)
+    # can never apply.
+    all_paths = sorted((ROOT / "ontology" / "modules").glob("*.ttl")) + sorted(
+        (ROOT / "ontology" / "views").glob("*.ttl")
+    )
+    for path in all_paths:
+        graph = Graph()
+        graph.parse(path, format="turtle")
+        for (subject, obj), tiers in sorted(_pair_tiers(graph).items()):
+            if len(tiers) > 1:
+                failures.append(
+                    f"{path.relative_to(ROOT)}: tier-mixed pair within one "
+                    f"module (tiers {'/'.join(sorted(tiers))}): {subject} -> {obj}"
+                )
+    # (b) No pair mixes tiers across the default build spine (which excludes
+    # alignment-research — the documented promotion-staging exception).
+    graph = Graph()
+    for name in SPINE:
+        graph.parse(ROOT / "ontology" / "modules" / name, format="turtle")
+    for (subject, obj), tiers in sorted(_pair_tiers(graph).items()):
+        if len(tiers) > 1:
+            failures.append(
+                f"tier-mixed pair across the default spine "
+                f"(tiers {'/'.join(sorted(tiers))}): {subject} -> {obj}"
+            )
+    return failures
 
 
 def check_dual_typing() -> list:

--- a/scripts/verify_method_shapes.py
+++ b/scripts/verify_method_shapes.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Behavioural check for ontology/shapes/method-shapes.ttl.
+
+The shapes carry the value constraint the 2026-08-13 methods-as-SKOS
+migration moved out of OWL: smn:basedOn values must be method concepts at
+or below smn:EnumerationMethod in smn:MethodScheme. Because the ontology
+itself contains no smn:AggregatedMeasurement instances, this check runs
+the shapes against a built-in fixture: a conforming instance (based on an
+enumeration method) must pass, and a violating instance (based on a
+fork-length method) must be flagged. Requires pyshacl.
+"""
+
+from pathlib import Path
+
+from pyshacl import validate
+from rdflib import Graph
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FIXTURE = """
+@prefix smn: <https://w3id.org/smn/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/> .
+
+smn:EnumerationMethod skos:inScheme smn:MethodScheme .
+smn:ForkLengthMeasurementLabMethod skos:inScheme smn:MethodScheme ;
+  skos:broader smn:ForkLengthMeasurementMethod .
+smn:ForkLengthMeasurementMethod skos:inScheme smn:MethodScheme ;
+  skos:broader smn:FishForkLengthMeasurementMethod .
+smn:FishForkLengthMeasurementMethod skos:inScheme smn:MethodScheme ;
+  skos:broader smn:FishLengthMeasurementMethod .
+smn:FishLengthMeasurementMethod skos:inScheme smn:MethodScheme .
+
+ex:conforming a smn:AggregatedMeasurement ; smn:basedOn smn:EnumerationMethod .
+ex:violating a smn:AggregatedMeasurement ; smn:basedOn smn:ForkLengthMeasurementLabMethod .
+"""
+
+
+def main() -> None:
+    data = Graph()
+    data.parse(data=FIXTURE, format="turtle")
+    shapes = Graph()
+    shapes.parse(ROOT / "ontology" / "shapes" / "method-shapes.ttl", format="turtle")
+    conforms, _, report_text = validate(data, shacl_graph=shapes, advanced=True)
+
+    failures = []
+    if conforms:
+        failures.append("expected the violating fixture instance to be flagged, "
+                        "but the report conforms")
+    # pyshacl may render focus nodes prefixed (ex:violating) or as full IRIs
+    if not any(m in report_text for m in ("ex:violating", "http://example.org/violating")):
+        failures.append("the violating instance is not named in the report")
+    if any(m in report_text for m in ("ex:conforming", "http://example.org/conforming")):
+        failures.append("the conforming instance was incorrectly flagged")
+
+    if failures:
+        for failure in failures:
+            print(failure)
+        print(report_text)
+        raise SystemExit(1)
+    print("Method shapes verified: violating fixture flagged, conforming fixture passes.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Completes step 1b of the alignment pass (metasalmon roadmap S9):

- **Read-only verification**: `build_rda_case_study_modules.py --check` composes in memory and fails on drift — `make test` no longer mutates the working tree, and hand-edits to generated modules 08/09 can no longer pass CI silently (both halves of the recon's tooling findings).
- **CONVENTIONS §5b enforced in CI**: `verify_mapping_policy.py` (foreign-subject axioms outside alignment modules · tier-mixed pairs · dual `owl:Class`/`skos:Concept` typing) and `verify_method_shapes.py` (pyshacl behavioural fixture: violating instance flagged, conforming passes) run in `make test`.
- **ELK reasoner gate** as a new CI job over the catalog-resolved modular closure (W3C SOSA–PROV alignment + PROV-O + SOSA included) — passes locally: consistent, zero unsatisfiable classes. This makes the neurosymbolic reasoner-clean invariant mechanical.
- Phantom `auto-generated; do not hand-edit` markers (no generator ever existed) replaced with honest markers in the case-study fragments; views documented as catalog-resolved, non-dereferenceable identifiers.

Remaining from step-1b acceptance: reasoning over the **main+gcdfo** closure, which needs step 3's cross-repo CI design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)