### PR TITLE
S9 step 3 (smn side): retarget the re-namespaced reference-point term

### DIFF
--- a/docs/smn.jsonld
+++ b/docs/smn.jsonld
@@ -212,6 +212,14 @@
     ]
   },
   {
+    "@id": "https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower",
+    "http://www.w3.org/2004/02/skos/core#closeMatch": [
+      {
+        "@id": "https://w3id.org/iadopt/ont/Constraint"
+      }
+    ]
+  },
+  {
     "@id": "https://w3id.org/iadopt/ont/Constraint",
     "@type": [
       "http://www.w3.org/2002/07/owl#Class"
@@ -2105,14 +2113,6 @@
     "http://www.w3.org/2000/01/rdf-schema#subClassOf": [
       {
         "@id": "https://w3id.org/smn/MorphologicalCharacteristic"
-      }
-    ]
-  },
-  {
-    "@id": "https://w3id.org/smn/FisheriesReferencePointLower",
-    "http://www.w3.org/2004/02/skos/core#closeMatch": [
-      {
-        "@id": "https://w3id.org/iadopt/ont/Constraint"
       }
     ]
   },

--- a/docs/smn.owl
+++ b/docs/smn.owl
@@ -2213,11 +2213,11 @@
         <rdfs:seeAlso rdf:resource="http://rs.tdwg.org/dwc/terms/protocol"/>
         <rdfs:seeAlso rdf:resource="https://rs.tdwg.org/dwc/dp/terms/Protocol"/>
     </rdf:Description>
+    <rdf:Description rdf:about="https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower">
+        <skos:closeMatch rdf:resource="https://w3id.org/iadopt/ont/Constraint"/>
+    </rdf:Description>
     <rdf:Description rdf:about="https://w3id.org/iadopt/ont/Property">
         <skos:closeMatch rdf:resource="http://www.w3.org/ns/sosa/Property"/>
-    </rdf:Description>
-    <rdf:Description rdf:about="https://w3id.org/smn/FisheriesReferencePointLower">
-        <skos:closeMatch rdf:resource="https://w3id.org/iadopt/ont/Constraint"/>
     </rdf:Description>
     <rdf:Description rdf:about="https://w3id.org/smn/broodYear">
         <ns1:IAO_0000115 xml:lang="en">Relates a data record or observation to the calendar year that identifies a salmon cohort by the spawning year of its parents.</ns1:IAO_0000115>

--- a/docs/smn.ttl
+++ b/docs/smn.ttl
@@ -1650,10 +1650,10 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
                                      <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
 
 
+<https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower> skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
+
+
 <https://w3id.org/iadopt/ont/Property> skos:closeMatch sosa:Property .
-
-
-<https://w3id.org/smn/FisheriesReferencePointLower> skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
 
 
 <https://w3id.org/smn/broodYear> ns1:IAO_0000115 "Relates a data record or observation to the calendar year that identifies a salmon cohort by the spawning year of its parents."@en ;

--- a/knowledge/data/cross-vocabulary-alignment-state.md
+++ b/knowledge/data/cross-vocabulary-alignment-state.md
@@ -11,7 +11,9 @@ psc:
 
 Verified 2026-08-12: smn main `3995a17`, gcdfo main `c7a5425` (release
 0.0.8), psc-salmon-vocabularies branch `feature/fair-mapping-products-roadmap`
-(`8e50d81`).
+(`8e50d81`). The step-3 resolutions below are verified against gcdfo
+PR #78 at commit `41f3c1b` (pending merge — re-pin to the merged
+main commit when it lands).
 
 ## The boundary is now structural, not prose
 
@@ -29,11 +31,14 @@ Any earlier claim that the smn/gcdfo boundary is "prose-only" is stale.
   dual-typed IRIs (verified against the flat build). PSC's wrong-kind
   objection (`sdo-alignment-gap.md`) no longer applies; updating their doc
   and drafting psc→smn SSSOM rows is step 4.
-- **Minted foreign term:** `smn:FisheriesReferencePointLower` is declared
-  only in `dfo-salmon.ttl` (~line 1920); smn never declares it.
+- ~~Minted foreign term~~ **Resolved 2026-08-13 (step 3, gcdfo PR #78):**
+  `smn:FisheriesReferencePointLower` is re-namespaced to
+  `gcdfo:FisheriesReferencePointLower` (policy-scoped like its sibling
+  reference-point terms); smn's two alignment rows retargeted.
 - ~~Unbridged duplication~~ **Resolved 2026-08-13 (step 3, gcdfo PR #78):**
-  `mappings/gcdfo-to-smn.sssom.tsv` publishes the boundary as data — 28
-  reviewed rows covering the age/year family, the renamed age classes,
+  `mappings/gcdfo-to-smn.sssom.tsv` publishes the boundary as data — 32
+  reviewed rows (incl. four replacement rows for the removed duplicate
+  properties) covering the age/year family, the renamed age classes,
   CatchYear, and EscapementEstimate, with predicates graded by smn's own
   migration provenance (Migrated → exactMatch, Adapted → closeMatch) and
   both sides version-pinned. The 2026-08-13 recon found **zero**

--- a/knowledge/data/cross-vocabulary-alignment-state.md
+++ b/knowledge/data/cross-vocabulary-alignment-state.md
@@ -31,14 +31,17 @@ Any earlier claim that the smn/gcdfo boundary is "prose-only" is stale.
   and drafting psc→smn SSSOM rows is step 4.
 - **Minted foreign term:** `smn:FisheriesReferencePointLower` is declared
   only in `dfo-salmon.ttl` (~line 1920); smn never declares it.
-- **Unbridged duplication:** the 18-term age/year SKOS family exists twice —
-  smn module 07 carries migrated copies ("Migrated from GC DFO…") while gcdfo
-  retains the `gcdfo:` originals with **zero** `skos:exactMatch` bridges in
-  either direction.
-- **Zero-delta duplicates:** four gcdfo object properties
-  (`hasFeatureOfInterest`, `hasObservationResult`, `isSampleOfStratum`,
-  `usesObservationProcedure`) duplicate their smn twins' labels, definitions,
-  domains, and ranges verbatim, differing only by a `subPropertyOf` link.
+- ~~Unbridged duplication~~ **Resolved 2026-08-13 (step 3, gcdfo PR #78):**
+  `mappings/gcdfo-to-smn.sssom.tsv` publishes the boundary as data — 28
+  reviewed rows covering the age/year family, the renamed age classes,
+  CatchYear, and EscapementEstimate, with predicates graded by smn's own
+  migration provenance (Migrated → exactMatch, Adapted → closeMatch) and
+  both sides version-pinned. The 2026-08-13 recon found **zero**
+  same-name-different-semantics collisions — the old "~55 collisions" figure
+  counted MIREOT mirrors and migrated-identical pairs.
+- ~~Zero-delta duplicates~~ **Resolved 2026-08-13 (step 3, gcdfo PR #78):**
+  the four duplicate object properties are removed; consumers use the smn
+  twins directly.
 
 ## Why PSC maps to gcdfo but refuses smn — the decisive field evidence
 

--- a/knowledge/log.md
+++ b/knowledge/log.md
@@ -27,3 +27,7 @@
   behavioural check wired into make test and CI, new ELK reasoner-gate CI job
   (passes: consistent, zero unsatisfiable classes), views documented as
   non-dereferenceable identifiers.
+- 2026-08-13 — S9 step 3 (smn side): the two alignment rows referencing the
+  never-declared smn:FisheriesReferencePointLower retarget the re-namespaced
+  gcdfo:FisheriesReferencePointLower (gcdfo PR 78 carries the rename and the
+  new gcdfo-to-smn SSSOM mapping set, 28 rows, pinned both sides).

--- a/ontology/modules/alignment-main.ttl
+++ b/ontology/modules/alignment-main.ttl
@@ -26,7 +26,10 @@ smn:Stock skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
 smn:IndicatorRiver skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
 
 smn:ReferencePoint skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
-smn:FisheriesReferencePointLower skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
+# Foreign-subject row (permitted here per CONVENTIONS 5b): the term was
+# re-namespaced to gcdfo on 2026-08-13 — it was minted as smn: in the gcdfo
+# file but never declared in smn, and it is DFO-policy-scoped.
+gcdfo:FisheriesReferencePointLower skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
 
 smn:Abundance skos:closeMatch qk:Population ;
   skos:broadMatch qk:Count ;

--- a/ontology/modules/alignment-research.ttl
+++ b/ontology/modules/alignment-research.ttl
@@ -1,3 +1,4 @@
+@prefix gcdfo:   <https://w3id.org/gcdfo/salmon#> .
 @prefix smn:  <https://w3id.org/smn/> .
 @prefix owl:     <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
@@ -49,7 +50,7 @@ smn:Stock skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
 smn:IndicatorRiver skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
 
 smn:ReferencePoint skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
-smn:FisheriesReferencePointLower skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
+gcdfo:FisheriesReferencePointLower skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
 
 #################################################################
 # Candidate bridge properties

--- a/ontology/modules/alignment-research.ttl
+++ b/ontology/modules/alignment-research.ttl
@@ -50,6 +50,10 @@ smn:Stock skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
 smn:IndicatorRiver skos:closeMatch <http://www.w3.org/ns/sosa/FeatureOfInterest> .
 
 smn:ReferencePoint skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
+# Foreign-subject row (CONVENTIONS 5b rationale, stated here because this
+# module is reviewable independently of alignment-main): the term is
+# gcdfo-owned since its 2026-08-13 re-namespacing — it was minted as smn:
+# in the gcdfo file but never declared in smn, and it is DFO-policy-scoped.
 gcdfo:FisheriesReferencePointLower skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
 
 #################################################################

--- a/salmon-domain-ontology.ttl
+++ b/salmon-domain-ontology.ttl
@@ -18,6 +18,8 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
     rdfs:seeAlso <http://rs.tdwg.org/dwc/terms/protocol>,
         <https://rs.tdwg.org/dwc/dp/terms/Protocol> .
 
+<https://w3id.org/gcdfo/salmon#FisheriesReferencePointLower> skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
+
 <https://w3id.org/iadopt/ont/Property> skos:closeMatch sosa:Property .
 
 <https://w3id.org/iadopt/ont/Variable> a owl:Class ;
@@ -200,8 +202,6 @@ sosa:ObservingProcedure rdfs:comment "Documentation-level bridge only: in salmon
     rdfs:label "Fish weight"@en ;
     rdfs:isDefinedBy <https://w3id.org/smn> ;
     rdfs:subClassOf <https://w3id.org/smn/MorphologicalCharacteristic> .
-
-<https://w3id.org/smn/FisheriesReferencePointLower> skos:closeMatch <https://w3id.org/iadopt/ont/Constraint> .
 
 <https://w3id.org/smn/ForkLengthMeasurement> a owl:Class ;
     rdfs:label "Fork-length measurement"@en ;


### PR DESCRIPTION
Companion to [dfo-salmon-ontology#78](https://github.com/dfo-pacific-science/dfo-salmon-ontology/pull/78): the two alignment rows referencing `smn:FisheriesReferencePointLower` — an IRI smn never declared — retarget the re-namespaced `gcdfo:FisheriesReferencePointLower`, and the knowledge bundle records the three resolved cross-vocabulary defects (minted term, unbridged age/year duplication → now the 28-row SSSOM set, zero-delta duplicate properties). `make ci` and the ELK gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)