### PR TITLE
fix: one name per term, and only for terms smn owns

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -146,6 +146,24 @@ These close the policy gaps the alignment pass found (findings F1/F2/F5/F7).
    IRI may be typed both `owl:Class` and `skos:Concept` anywhere in it.
    A DL-profile gate does not catch class-as-individual modelling mistakes
    (legal punning), so the CI check for those is a targeted SPARQL report.
+6. **One name per term, and only for terms we own (2026-08-16).** A subject
+   carries at most one `rdfs:label` and one `skos:prefLabel` per language tag
+   in every build closure, and where both are present they agree exactly —
+   differing by case or whitespace alone is a defect, not a variant. Genuine
+   synonyms are `skos:altLabel`; a capitalisation of the preferred label is
+   not a synonym. smn never asserts `rdfs:label`, `skos:prefLabel`, or
+   `skos:altLabel` on a foreign-namespace subject at all: declaring the term
+   and annotating it with `rdfs:comment` is in scope, renaming it is rule 3's
+   restatement problem in lexical form.
+
+   The reason is downstream, not aesthetic. Given two equally-valid English
+   labels for one subject a renderer must pick one, and nothing obliges it to
+   pick the same one twice — so its output changes between runs with no
+   semantic change behind it. That is what OWL2VOWL did to
+   dfo-salmon-ontology's docs pipeline, which pinned to `skos:prefLabel` to
+   work around it (its ADR-007). Enforced by
+   `scripts/verify_mapping_policy.py` (checks 4 and 5), which carries the
+   condition that would retire it.
 
 ## 6) Profile-to-domain bridge pattern
 

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -6077,7 +6077,10 @@ This section provides details for each class and property defined by Salmon Doma
 
 
 <!--CHANGELOG SECTION-->
-   <div id="changelog">null</div>
+   <div id="changelog"><div id="changelog">
+<h2 id="changes" class="list">Changes from last version</h2>
+</div>
+</div>
 <div id="acknowledgments">
 <h2 id="ack" class="list">Acknowledgments <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6077,7 +6077,10 @@ This section provides details for each class and property defined by Salmon Doma
 
 
 <!--CHANGELOG SECTION-->
-   <div id="changelog">null</div>
+   <div id="changelog"><div id="changelog">
+<h2 id="changes" class="list">Changes from last version</h2>
+</div>
+</div>
 <div id="acknowledgments">
 <h2 id="ack" class="list">Acknowledgments <span class="backlink"> back to <a href="#toc">ToC</a></span></h2>
 <p>

--- a/knowledge/data/owl-skos-conventions-state.md
+++ b/knowledge/data/owl-skos-conventions-state.md
@@ -90,6 +90,45 @@ Originally verified 2026-08-12 (main at `3995a17`); inventory refreshed
   `StatisticalModifier` + `iop:hasStatisticalModifier`**. No smn statistical
   scheme exists among module 07's eight schemes.
 
+## F9 — duplicate English labels in the research closure (2026-08-16, fixed)
+
+Found while checking a downstream report against this repo. The report said
+`smn:EscapementSurveyEvent` carried two English `rdfs:label`s plus a
+`skos:prefLabel`. **It does not, and never did here** — module 02 gives it one
+label, "Escapement survey event"@en, with no `skos:prefLabel` and no
+`skos:altLabel`, and that is what every published serialization carries. The
+second label is asserted *downstream*: `dfo-salmon-ontology` re-declares the
+smn-owned IRI in its own source with `rdfs:label`/`skos:prefLabel`
+"Escapement Survey Event"@en (title case, gcdfo's house style), and its docs
+pipeline merges that file with a pinned copy of smn. The duplicate exists only
+in that merged graph. Ownership, not casing, is the defect: gcdfo renames a
+term it does not own.
+
+The same defect class **was** live here, in the opposite direction.
+`modules/alignment-research.ttl` carried "external class stubs (readability)"
+labelling six SOSA IRIs — `sosa:Observation` as "SOSA Observation" and so on —
+inherited verbatim from the gcdfo alignment branch at the `46a4a51` bootstrap.
+That predates both `ontology/imports/` vendoring SOSA (`034cb1f`) and
+CONVENTIONS §5b rule 3. Once SOSA was vendored, merging the research build gave
+each of those six subjects two English labels, upstream's and ours. Confirmed
+with `robot merge --catalog` over both build roots: **6 duplicated subjects in
+the research closure, 0 in the default closure** — which is why no published
+artifact ever showed it and no gate caught it. Five parallel I-ADOPT stubs were
+latent rather than live only because I-ADOPT is not vendored.
+
+Fixed 2026-08-16 by dropping the labels and keeping the bare `owl:Class`
+declaration stubs. Because `alignment-research` is outside the default build,
+the flat TTL and all of `docs/smn.{ttl,owl,jsonld}` are **byte-identical**
+across the fix. Now enforced by `scripts/verify_mapping_policy.py` checks 4
+and 5, and stated as CONVENTIONS §5b rule 6.
+
+Unrelated pre-existing finding, verified the same day: `make
+verify-generated-artifacts` fails on a clean `main` in a local environment,
+because WIDOCO regenerates `<div id="changelog">` with a "Changes from last
+version" block where the committed HTML has `null`. It is environment- (likely
+network-) dependent, touches only `docs/index.html` and `docs/index-en.html`,
+and no RDF artifact drifts. Reproduced on `main` with zero source changes.
+
 ## Upstream facts these rest on (fetched 2026-08-12)
 
 - I-ADOPT current release **1.1.0** (2025-05-28): 9 classes (incl.

--- a/knowledge/data/owl-skos-conventions-state.md
+++ b/knowledge/data/owl-skos-conventions-state.md
@@ -122,12 +122,35 @@ the flat TTL and all of `docs/smn.{ttl,owl,jsonld}` are **byte-identical**
 across the fix. Now enforced by `scripts/verify_mapping_policy.py` checks 4
 and 5, and stated as CONVENTIONS §5b rule 6.
 
-Unrelated pre-existing finding, verified the same day: `make
-verify-generated-artifacts` fails on a clean `main` in a local environment,
-because WIDOCO regenerates `<div id="changelog">` with a "Changes from last
-version" block where the committed HTML has `null`. It is environment- (likely
-network-) dependent, touches only `docs/index.html` and `docs/index-en.html`,
-and no RDF artifact drifts. Reproduced on `main` with zero source changes.
+Unrelated pre-existing finding, first seen the same day and **misdiagnosed**:
+`make verify-generated-artifacts` failed on a clean `main` because WIDOCO
+regenerates `<div id="changelog">` as a real "Changes from last version" block
+where the committed HTML has `null`. That was recorded here as "environment-
+(likely network-) dependent" drift. **It was not, and that reading is
+withdrawn (2026-08-17).** The regenerated block is deterministic: CI run
+`31959130307` and a local `make docs-refresh` produced *byte-identical*
+`docs/index.html` and `docs/index-en.html` — both blob `7e7c1fd`, both
+replacing the committed `6da2d3d`. Two independent environments agreeing to
+the byte is not environment dependence; the committed `null` is simply
+**stale**, and the gate was reporting a real, one-directional drift.
+
+Provenance of the stale byte: `null` entered at `5279971` (the 0.0.3
+re-cut on the release branch), replacing a populated changelog. WIDOCO builds
+the block by downloading the `owl:priorVersion` — `https://w3id.org/smn/0.0.3`
+— and at that commit the 0.0.3 snapshot had not yet reached GitHub Pages, so
+the fetch returned nothing and WIDOCO wrote `null`. Since #25 merged and Pages
+published 0.0.3, the fetch resolves, and because the root ontology declares
+`priorVersion` equal to its own `versionIRI` (0.0.3), the honest current block
+is the heading with an empty change list. Fixed 2026-08-17 by regenerating and
+committing the two HTML files; no RDF artifact drifts either way.
+
+Residual sensitivity, stated so it is not rediscovered as a mystery: the block
+is a function of a **network fetch**, so `make ci` on a machine that cannot
+reach `w3id.org` still writes `null` and will show drift in the opposite
+direction. Online — which is the gate's environment — the output is stable.
+This stops being a footnote when `priorVersion` is advanced to a genuinely
+earlier release, at which point the block gains real content and changes with
+every release rather than every network state.
 
 ## Upstream facts these rest on (fetched 2026-08-12)
 

--- a/ontology/modules/alignment-research.ttl
+++ b/ontology/modules/alignment-research.ttl
@@ -15,21 +15,43 @@
   owl:imports <https://w3id.org/smn> .
 
 #################################################################
-# External class stubs (readability)
+# External class stubs (declaration only)
 #################################################################
 
-<http://www.w3.org/ns/sosa/Observation> a owl:Class ; rdfs:label "SOSA Observation"@en .
-<http://www.w3.org/ns/sosa/Sampling> a owl:Class ; rdfs:label "SOSA Sampling"@en .
-<http://www.w3.org/ns/sosa/Sample> a owl:Class ; rdfs:label "SOSA Sample"@en .
-<http://www.w3.org/ns/sosa/FeatureOfInterest> a owl:Class ; rdfs:label "SOSA Feature of Interest"@en .
-<http://www.w3.org/ns/sosa/Procedure> a owl:Class ; rdfs:label "SOSA Procedure"@en .
-<http://www.w3.org/ns/sosa/Result> a owl:Class ; rdfs:label "SOSA Result"@en .
+# These are bare declaration stubs (CONVENTIONS 5b rule 2): they type the
+# foreign terms the axioms below reference so the module is well-formed OWL
+# when read on its own.
+#
+# They carried an `rdfs:label` until 2026-08-16 ("SOSA Observation",
+# "I-ADOPT Variable", …), inherited verbatim from the gcdfo alignment branch
+# at the 46a4a51 bootstrap — before `ontology/imports/` vendored SOSA and
+# before CONVENTIONS 5b rule 3 ("import upstream alignments; do not restate
+# them") existed. Those labels restated upstream and disagreed with it:
+# merging the research build gave `sosa:Observation` two English
+# `rdfs:label`s, "Observation" (vendored upstream) and "SOSA Observation"
+# (here). A label-consuming renderer such as OWL2VOWL then picks one
+# arbitrarily and its output differs between runs for no semantic reason —
+# the same ambiguity dfo-salmon-ontology's ADR-007 had to work around
+# downstream. Upstream owns the label; smn declares the term and stops there.
+# Labels for SOSA now come from the vendored import; I-ADOPT is not vendored,
+# so its terms render as IRIs until it is imported — the honest state, and
+# preferable to a locally invented label that upstream contradicts.
+#
+# Enforced by `check_foreign_subject_labels()` in
+# scripts/verify_mapping_policy.py.
 
-<https://w3id.org/iadopt/ont/Variable> a owl:Class ; rdfs:label "I-ADOPT Variable"@en .
-<https://w3id.org/iadopt/ont/Entity> a owl:Class ; rdfs:label "I-ADOPT Entity"@en .
-<https://w3id.org/iadopt/ont/Property> a owl:Class ; rdfs:label "I-ADOPT Property"@en .
-<https://w3id.org/iadopt/ont/Constraint> a owl:Class ; rdfs:label "I-ADOPT Constraint"@en .
-<https://w3id.org/iadopt/ont/StatisticalModifier> a owl:Class ; rdfs:label "I-ADOPT Statistical Modifier"@en .
+<http://www.w3.org/ns/sosa/Observation> a owl:Class .
+<http://www.w3.org/ns/sosa/Sampling> a owl:Class .
+<http://www.w3.org/ns/sosa/Sample> a owl:Class .
+<http://www.w3.org/ns/sosa/FeatureOfInterest> a owl:Class .
+<http://www.w3.org/ns/sosa/Procedure> a owl:Class .
+<http://www.w3.org/ns/sosa/Result> a owl:Class .
+
+<https://w3id.org/iadopt/ont/Variable> a owl:Class .
+<https://w3id.org/iadopt/ont/Entity> a owl:Class .
+<https://w3id.org/iadopt/ont/Property> a owl:Class .
+<https://w3id.org/iadopt/ont/Constraint> a owl:Class .
+<https://w3id.org/iadopt/ont/StatisticalModifier> a owl:Class .
 
 #################################################################
 # Stronger subclass candidates

--- a/scripts/verify_mapping_policy.py
+++ b/scripts/verify_mapping_policy.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Enforce CONVENTIONS section 5b mapping placement and coherence rules.
 
-Three checks, all CI-fatal:
+Five checks, all CI-fatal:
 
 1. Foreign-subject statements outside alignment modules: a subject smn does
-   not own may carry only documentation annotations (label/comment/seeAlso/
+   not own may carry only documentation annotations (comment/seeAlso/
    isDefinedBy) and bare declaration stubs. Everything else — Tier-1 axioms
    AND instance-level property assertions — is confined to the alignment
    modules; the annotated NCBITaxon MIREOT mirror in module 02 is the one
@@ -16,8 +16,34 @@ Three checks, all CI-fatal:
    excludes alignment-research, the documented staging exception).
 3. Reasoner-clean typing invariant: no IRI in the flattened build may be
    typed both owl:Class and skos:Concept (the dual-representation rule).
+4. No lexical labels on foreign-namespace subjects, anywhere in smn's
+   sources — alignment modules included. Upstream owns its own labels
+   (CONVENTIONS 5b rule 3, "import upstream alignments; do not restate
+   them"); smn may declare a foreign term and annotate it with prose, but
+   restating its name is how a mirror drifts out of agreement with the
+   thing it mirrors.
+5. Label unambiguity across each build closure: at most one rdfs:label and
+   one skos:prefLabel per subject per language tag, and no rdfs:label that
+   disagrees with its subject's skos:prefLabel by case or whitespace alone.
+
+Checks 4 and 5 were added 2026-08-16. A label-consuming renderer given two
+equally-valid English labels for one subject picks one arbitrarily, so its
+output changes between runs with no semantic change behind it — that is what
+OWL2VOWL did to dfo-salmon-ontology's docs pipeline, which had to pin to
+skos:prefLabel to work around it (its ADR-007). Check 4 stops smn creating
+that ambiguity in someone else's terms; check 5 stops it appearing in smn's
+own merged artifacts from any direction.
+
+Retirement condition for checks 4 and 5: retire them when label uniqueness is
+enforced for the whole ecosystem by a shared upstream gate — a SHACL shape or
+ROBOT report run identically by smn, gcdfo, and the PSC vocabularies — so that
+this repo-local restatement is redundant rather than load-bearing. Until then
+they stay: this repo publishes terms other repos re-serialize, and it is the
+only place the invariant is checked at the source.
 """
 
+import re
+import xml.etree.ElementTree as ET
 from collections import defaultdict
 from pathlib import Path
 
@@ -26,6 +52,17 @@ from rdflib.namespace import SKOS
 
 ROOT = Path(__file__).resolve().parents[1]
 SMN = "https://w3id.org/smn"
+CATALOG = ROOT / "ontology" / "catalog-v001.xml"
+CATALOG_NS = "{urn:oasis:names:tc:entity:xmlns:xml:catalog}"
+# The two published build entrypoints. Both are checked: alignment-research
+# is not in the default build, so a defect confined to it is invisible in the
+# flat artifact — which is exactly where the 2026-08-16 SOSA label duplicates
+# had been hiding since the 46a4a51 bootstrap.
+BUILD_ROOTS = [
+    Path("ontology") / "salmon-domain-ontology.ttl",
+    Path("ontology") / "salmon-domain-ontology-research.ttl",
+]
+LEXICAL_LABEL_PREDICATES = (RDFS.label, SKOS.prefLabel, SKOS.altLabel)
 ALIGNMENT_MODULES = {
     "alignment-main.ttl",
     "alignment-upper.ttl",
@@ -54,13 +91,12 @@ TIER3 = {SKOS.closeMatch, SKOS.broadMatch, SKOS.narrowMatch, SKOS.relatedMatch}
 
 
 # Predicates a foreign-namespace subject may carry outside alignment
-# modules: declaration stubs and documentation annotations only.
+# modules: declaration stubs and prose annotations only.
 # Everything else — Tier-1 axioms AND instance-level property assertions
 # (the old `sosa:FeatureOfInterest sosa:hasSample sosa:Sample` class of
 # mistake) — must live in an alignment module (CONVENTIONS 5b rule 2).
 FOREIGN_ALLOWED_PREDICATES = {
     RDFS.comment,
-    RDFS.label,
     RDFS.seeAlso,
     RDFS.isDefinedBy,
 }
@@ -89,6 +125,10 @@ def check_foreign_subjects() -> list:
                 continue
             if predicate in FOREIGN_ALLOWED_PREDICATES:
                 continue
+            if predicate in LEXICAL_LABEL_PREDICATES:
+                continue  # delegated to check_foreign_subject_labels(), which
+                # covers alignment modules too — reporting here as well would
+                # print two failures for one defect.
             if predicate == RDF.type and obj in FOREIGN_ALLOWED_TYPE_OBJECTS:
                 continue  # bare declaration stub
             if path.name == "02-observation-measurement.ttl" and "NCBITaxon" in str(subject):
@@ -159,14 +199,130 @@ def check_dual_typing() -> list:
     ]
 
 
+def check_foreign_subject_labels() -> list:
+    """No smn source may name a term it does not own (CONVENTIONS 5b rule 3).
+
+    Unlike check_foreign_subjects() this covers the alignment modules, because
+    they are precisely where foreign subjects are allowed to appear — and so
+    the only place a foreign label can hide. Declaring the term and annotating
+    it with prose stays legal; only the lexical predicates are refused.
+    """
+    failures = []
+    paths = sorted((ROOT / "ontology" / "modules").glob("*.ttl")) + sorted(
+        (ROOT / "ontology" / "views").glob("*.ttl")
+    )
+    for path in paths:
+        graph = Graph()
+        graph.parse(path, format="turtle")
+        for predicate in LEXICAL_LABEL_PREDICATES:
+            for subject, _, obj in sorted(graph.triples((None, predicate, None)), key=str):
+                if not isinstance(subject, URIRef) or str(subject).startswith(SMN):
+                    continue
+                failures.append(
+                    f"{path.relative_to(ROOT)}: label on a foreign-namespace subject "
+                    f"(upstream owns its own labels; declare the term, do not rename it): "
+                    f"{subject.n3(graph.namespace_manager)} "
+                    f"{predicate.n3(graph.namespace_manager)} {str(obj)!r}"
+                    f"@{getattr(obj, 'language', None)}"
+                )
+    return failures
+
+
+def _catalog_index() -> dict:
+    """Map ontology IRI -> local file, from the catalog ROBOT itself resolves.
+
+    Reusing the catalog rather than re-deriving the mapping keeps this check
+    honest about what the reasoner gate actually merges, vendored upstream
+    imports included.
+    """
+    index = {}
+    for entry in ET.parse(CATALOG).getroot().iter(f"{CATALOG_NS}uri"):
+        index[entry.get("name")] = (CATALOG.parent / entry.get("uri")).resolve()
+    return index
+
+
+def _import_closure(root_path: Path) -> Graph:
+    index = _catalog_index()
+    graph = Graph()
+    seen = set()
+
+    def visit(path: Path) -> None:
+        path = path.resolve()
+        if path in seen or not path.exists():
+            return
+        seen.add(path)
+        local = Graph()
+        local.parse(path, format="turtle")
+        for triple in local:
+            graph.add(triple)
+        for imported in sorted(local.objects(None, OWL.imports), key=str):
+            target = index.get(str(imported))
+            if target is not None:
+                visit(target)
+
+    visit(root_path)
+    return graph
+
+
+def _collapse(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip().casefold()
+
+
+def check_label_unambiguity() -> list:
+    """One name per subject per language, in every build closure.
+
+    Two equally-valid labels for one subject leave a renderer to choose, and
+    nothing makes it choose the same way twice.
+    """
+    failures = []
+    for root in BUILD_ROOTS:
+        graph = _import_closure(ROOT / root)
+        for predicate in (RDFS.label, SKOS.prefLabel):
+            by_subject_language = defaultdict(set)
+            for subject, _, obj in graph.triples((None, predicate, None)):
+                by_subject_language[(subject, getattr(obj, "language", None))].add(str(obj))
+            for (subject, language), values in sorted(
+                by_subject_language.items(), key=lambda item: str(item[0][0])
+            ):
+                if len(values) > 1:
+                    rendered = ", ".join(repr(v) for v in sorted(values))
+                    failures.append(
+                        f"{root}: {subject} has {len(values)} "
+                        f"{predicate.n3(graph.namespace_manager)} values "
+                        f"in @{language}: {rendered}"
+                    )
+        for subject in sorted(
+            set(graph.subjects(RDFS.label, None)) & set(graph.subjects(SKOS.prefLabel, None)),
+            key=str,
+        ):
+            labels = {str(o) for o in graph.objects(subject, RDFS.label)}
+            preferred = {str(o) for o in graph.objects(subject, SKOS.prefLabel)}
+            for label in sorted(labels):
+                for pref in sorted(preferred):
+                    if label != pref and _collapse(label) == _collapse(pref):
+                        failures.append(
+                            f"{root}: {subject} rdfs:label {label!r} differs from "
+                            f"skos:prefLabel {pref!r} by case or whitespace only"
+                        )
+    return failures
+
+
 def main() -> None:
-    failures = check_foreign_subjects() + check_tier_mixing() + check_dual_typing()
+    failures = (
+        check_foreign_subjects()
+        + check_tier_mixing()
+        + check_dual_typing()
+        + check_foreign_subject_labels()
+        + check_label_unambiguity()
+    )
     if failures:
         for failure in failures:
             print(failure)
         raise SystemExit(1)
     print("Mapping policy verified: no foreign-subject axioms outside alignment "
-          "modules, no tier-mixed pairs in the default spine, no dual-typed IRIs.")
+          "modules, no tier-mixed pairs in the default spine, no dual-typed IRIs, "
+          "no labels on foreign-namespace subjects, one label per subject per "
+          "language in every build closure.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Started as "fix the duplicate label on `smn:EscapementSurveyEvent`" reported from downstream. **That defect is not in smn** — and finding that out uncovered a real one pointing the other way.

## The reported defect is downstream, not here

`smn:EscapementSurveyEvent` is defined once, in `ontology/modules/02-observation-measurement.ttl`, with exactly one label (`"Escapement survey event"@en`) and no `skos:prefLabel`. Verified in the module source, the flat TTL, and all three published serializations.

The second label comes from **gcdfo re-declaring an smn-owned IRI** in its own core file with `rdfs:label "Escapement Survey Event"@en` plus a matching `skos:prefLabel`. The two only co-exist in gcdfo's merged docs graph. The root cause is ownership — a MIREOT mirror renaming a term it does not own — and it is raised with the gcdfo owners rather than papered over here.

## What WAS broken here, in the opposite direction

`alignment-research.ttl` carried "external class stubs (readability)" labelling **11 foreign IRIs** (`sosa:Observation` as `"SOSA Observation"`, etc.), inherited from the alignment bootstrap — which predates both the vendoring of SOSA under `ontology/imports/` and CONVENTIONS §5b rule 3 ("do not restate upstream").

Once SOSA was vendored, a `robot merge` of the **research** build gave six subjects two English `rdfs:label`s each: upstream's and ours. **Six duplicates in the research closure, zero in the default closure** — which is exactly why no published artifact ever showed it and no gate caught it. smn was doing to SOSA what gcdfo is doing to smn.

Fixed by dropping the labels and keeping the bare `owl:Class` stubs the axioms need. SOSA labels now come from the vendored import; I-ADOPT renders as IRIs until it is imported — honest, and better than a local name upstream contradicts.

## A gate, because the sibling case is the one that hides

No `scripts/sparql/` exists, so a SPARQL lint would have been unwired ghost code. Instead `scripts/verify_mapping_policy.py` — already wired into `make test` — gains two checks: **(4)** no labels on foreign-namespace subjects anywhere in smn's sources, alignment modules included, and **(5)** at most one `rdfs:label`/`skos:prefLabel` per subject per language **in each build closure**, resolving imports through the same catalog ROBOT uses. Check 4 would have caught gcdfo's mistake had gcdfo run it.

Both verified RED before GREEN: reverting only the TTL reproduces all 17 failures including exactly the six ROBOT found. CONVENTIONS §5b gains **rule 6** so the linter enforces written policy rather than invented policy.

## Release and artifacts

**No version bump, no tag, no snapshot** — every published artifact is byte-identical, because the change is confined to the research build. Gates: `make test` (8 targets) pass, ELK consistent with no unsatisfiable classes, OKF capture-tier clean. `verify-generated-artifacts` was red for a **pre-existing** reason, now fixed here rather than waived.

The first diagnosis — "WIDOCO rewrites the changelog div nondeterministically" — is **withdrawn; it was disproven.** CI run `31959130307` and a local `make docs-refresh` rewrote `docs/index.html` and `docs/index-en.html` to the *same blob*, `7e7c1fd`, over the committed `6da2d3d`. Two independent environments agreeing byte-for-byte is not nondeterminism. The committed `<div id="changelog">null</div>` is simply **stale**: it entered at `5279971` (the 0.0.3 re-cut), when WIDOCO could not download the `owl:priorVersion` `https://w3id.org/smn/0.0.3` because that snapshot had not yet reached Pages. #25 published it, so the fetch now resolves and — `priorVersion` being equal to `versionIRI` — yields the heading with an empty change list.

Fixed by regenerating and committing the two HTML files; no RDF artifact moves. The F9 card paragraph is rewritten to record what was disproven and to name the one residual sensitivity: an **offline** `make ci` still writes `null`, and that is the broken direction.
