### PR TITLE
docs: route durable salmon knowledge to salmon-knowledge-commons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,34 @@ Sequencing for cross-vocabulary work lives in the **metasalmon hub**
 `metasalmon/knowledge/plans/2026-08-12-ontology-alignment-pass.md`. Do not
 maintain a competing roadmap here.
 
+## Domain knowledge goes to the commons
+
+`knowledge/` here records facts about **this repo** — the import graph, where
+practice diverges from `CONVENTIONS.md`, the alignment state. Facts about
+**salmon** go to
+[`salmon-knowledge-commons`](https://github.com/salmon-data-mobilization/salmon-knowledge-commons):
+biology, ecology, management, what a term actually means, why a modelling
+choice went the way it did.
+
+Write them there rather than into a PR description, a commit message or a chat
+transcript. Those evaporate, and the next agent re-derives the finding — which
+in an ontology means minting a second term for a distinction someone already
+worked out and did not write down. The reasoning behind a class is usually
+worth more than the class, and `rdfs:comment` is too small to hold it.
+
+If you can push there, open a PR. If you cannot, put the finding **in your
+report with its sources** so a maintainer can. Source-backed claims only — the
+commons rejects a claim with no citation — and **never assert your own
+verification**: `generated` says who wrote a card, `verified` says who
+independently checked it.
+
+**This repo is the far end of the commons' gap register.** A commons card that
+finds no term for a concept records a gap with a `mint_target`, and for shared
+all-agency biology that target is `smn` — here. Those gaps are drafted term
+requests, and they arrive with the sources already attached. Reading them is a
+reasonable way to decide what to mint next; **no agent mints from them
+unilaterally**, and the commons says so on its own side too.
+
 ## Before changing docs / ontology / builds
 
 - `knowledge/index.md` — verified repo knowledge (OKF bundle)


### PR DESCRIPTION
Adds one section to `AGENTS.md`, after the Coordination section. No ontology change.

**Do not merge yet** — one of six matching PRs across the hub nodes, for review together.

## Why

`knowledge/` here is about *this repo*: the verified import graph, where practice diverges from `CONVENTIONS.md`, the cross-vocabulary alignment state. Facts about **salmon** — biology, ecology, management, what a term actually means — have had no home, so they have been landing in PR descriptions and chat transcripts.

In an ontology repo that has a specific cost. When the reasoning behind a class evaporates, the next agent re-derives it and mints a second term for a distinction someone already worked out. `rdfs:comment` is too small to hold that reasoning, and it was never the right place for it.

## What the section says

Write it to [`salmon-knowledge-commons`](https://github.com/salmon-data-mobilization/salmon-knowledge-commons). Open a PR there if you can push; otherwise put the finding in your report with its sources. Source-backed claims only, and never assert your own verification.

It also records the relationship that matters most for this repo specifically: **`smn` is the far end of the commons' gap register.** A commons card that finds no term for a concept records a gap with a `mint_target`, and for shared all-agency biology that target is `smn` — here. Those gaps are drafted term requests that arrive with their sources already attached. Reading them is a reasonable way to decide what to mint next; the section is explicit that no agent mints from them unilaterally, which is also what the commons says on its own side.

## Context

There is now a live example: [salmon-knowledge-commons#1](https://github.com/salmon-data-mobilization/salmon-knowledge-commons/pull/1) adds seven concepts and 24 gaps, 18 of which target `smn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)